### PR TITLE
Implement dark mode for web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -1,19 +1,29 @@
 .admin-app {
   display: flex;
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
+  background: var(--admin-sidebar-bg);
   color: white;
   padding: 24px;
+  transition: background-color 0.3s ease;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+  gap: 12px;
 }
 
 .sidebar h1 {
   font-size: 24px;
-  margin-bottom: 32px;
   color: white;
+  margin: 0;
 }
 
 .sidebar nav {
@@ -33,11 +43,11 @@
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--admin-nav-hover);
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--admin-nav-active);
 }
 
 .main-content {

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import ThemeToggle from '../shared/ThemeToggle';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -36,7 +37,10 @@ const AdminApp: React.FC = () => {
   return (
     <div className="admin-app">
       <div className="sidebar">
-        <h1>Admin Panel</h1>
+        <div className="sidebar-header">
+          <h1>Admin Panel</h1>
+          <ThemeToggle />
+        </div>
         <nav>
           <button
             className={`nav-item ${currentTab === 'inventory' ? 'active' : ''}`}

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -11,8 +12,10 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <ApolloProvider client={apolloClient}>
-      <AdminApp />
-    </ApolloProvider>
+    <ThemeProvider>
+      <ApolloProvider client={apolloClient}>
+        <AdminApp />
+      </ApolloProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +25,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +53,19 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
+  transition: background-color 0.3s ease;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
 }
 
 .col-image img {
@@ -73,17 +77,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .state-badge {
@@ -103,31 +107,42 @@
   color: #721c24;
 }
 
+body[data-theme='dark'] .state-badge.available {
+  background: #1e4620;
+  color: #a3d9a5;
+}
+
+body[data-theme='dark'] .state-badge.off-shelf {
+  background: #4a1f23;
+  color: #f5b7bd;
+}
+
 .col-actions {
   position: relative;
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--bg-tertiary);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--border-color);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--shadow-color);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +152,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .action-menu button:last-child {
@@ -148,7 +163,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
 }
 
 .pagination {
@@ -161,21 +176,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--btn-primary-bg);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--btn-primary-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--btn-primary-bg-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,42 +21,44 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
+  transition: background-color 0.3s ease;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .state-badge.processing {
@@ -76,4 +79,24 @@
 .state-badge.canceled {
   background: #f8d7da;
   color: #721c24;
+}
+
+body[data-theme='dark'] .state-badge.processing {
+  background: #4a4320;
+  color: #ffd580;
+}
+
+body[data-theme='dark'] .state-badge.shipped {
+  background: #1a3a5a;
+  color: #80c0ff;
+}
+
+body[data-theme='dark'] .state-badge.completed {
+  background: #1e4620;
+  color: #a3d9a5;
+}
+
+body[data-theme='dark'] .state-badge.canceled {
+  background: #4a1f23;
+  color: #f5b7bd;
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .header-actions {
@@ -29,10 +29,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--border-color);
 }
 
 .form-row {
@@ -60,5 +60,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--border-color);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -11,8 +12,10 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <ApolloProvider client={apolloClient}>
-      <CustomerApp />
-    </ApolloProvider>
+    <ThemeProvider>
+      <ApolloProvider client={apolloClient}>
+        <CustomerApp />
+      </ApolloProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -1,5 +1,6 @@
 .checkout-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .empty-cart {
@@ -9,7 +10,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +41,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +60,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--bg-tertiary);
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
+  transition: background-color 0.2s;
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--border-color);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +80,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--text-primary);
 }
 
 .item-total {
@@ -88,7 +91,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .cart-summary {
@@ -99,7 +102,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +111,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--border-color);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -1,10 +1,11 @@
 .landing-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--bg-secondary);
+  box-shadow: 0 2px 4px var(--shadow-color);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +13,23 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--btn-primary-bg);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -29,10 +37,11 @@
   align-items: center;
   gap: 8px;
   font-size: 18px;
+  transition: background-color 0.2s;
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--btn-primary-bg-hover);
 }
 
 .cart-icon {
@@ -40,7 +49,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--btn-danger-bg);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,22 +83,26 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--btn-primary-bg);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .observer-target {
   height: 20px;
+}
+
+.loading {
+  color: var(--text-secondary);
 }

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import ThemeToggle from '../../shared/ThemeToggle';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -60,12 +61,15 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <ThemeToggle />
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -1,5 +1,6 @@
 .payment-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .payment-form {
@@ -10,24 +11,26 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--btn-danger-bg);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   border-radius: 8px;
+  transition: background-color 0.3s ease;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--text-primary);
 }
 
 .summary-row {
@@ -39,7 +42,7 @@
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--bg-tertiary);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,13 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
   z-index: 1;
+  transition: background-color 0.2s;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--border-color);
 }
 
 .product-detail {
@@ -51,12 +52,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +70,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--btn-primary-bg);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -3,6 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: var(--bg-primary);
 }
 
 .thankyou-card {
@@ -26,13 +27,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const savedTheme = localStorage.getItem('theme');
+    return (savedTheme as Theme) || 'light';
+  });
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/src/ts/web/src/shared/ThemeToggle.css
+++ b/src/ts/web/src/shared/ThemeToggle.css
@@ -1,0 +1,22 @@
+.theme-toggle {
+  background: var(--toggle-bg);
+  color: var(--text-primary);
+  padding: 8px 12px;
+  border-radius: 20px;
+  font-size: 20px;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+  background: var(--toggle-bg-hover);
+}
+
+.theme-toggle:active {
+  transform: scale(0.95);
+}

--- a/src/ts/web/src/shared/ThemeToggle.tsx
+++ b/src/ts/web/src/shared/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTheme } from './ThemeContext';
+import './ThemeToggle.css';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button 
+      className="theme-toggle" 
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -4,13 +4,75 @@
   box-sizing: border-box;
 }
 
+:root {
+  /* Light mode colors */
+  --bg-primary: #f5f5f5;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #e9ecef;
+  --text-primary: #333333;
+  --text-secondary: #666666;
+  --text-tertiary: #999999;
+  --border-color: #dddddd;
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --shadow-color-hover: rgba(0, 0, 0, 0.15);
+  --overlay-bg: rgba(0, 0, 0, 0.5);
+  --toggle-bg: #f0f0f0;
+  --toggle-bg-hover: #e0e0e0;
+  
+  /* Button colors */
+  --btn-primary-bg: #007bff;
+  --btn-primary-bg-hover: #0056b3;
+  --btn-primary-disabled: #cccccc;
+  --btn-secondary-bg: #6c757d;
+  --btn-secondary-bg-hover: #545b62;
+  --btn-danger-bg: #dc3545;
+  --btn-danger-bg-hover: #c82333;
+  
+  /* Admin colors */
+  --admin-sidebar-bg: #2c3e50;
+  --admin-nav-hover: rgba(255, 255, 255, 0.1);
+  --admin-nav-active: #3498db;
+}
+
+body[data-theme='dark'] {
+  /* Dark mode colors */
+  --bg-primary: #1a1a1a;
+  --bg-secondary: #2d2d2d;
+  --bg-tertiary: #3a3a3a;
+  --text-primary: #e0e0e0;
+  --text-secondary: #b0b0b0;
+  --text-tertiary: #808080;
+  --border-color: #404040;
+  --shadow-color: rgba(0, 0, 0, 0.3);
+  --shadow-color-hover: rgba(0, 0, 0, 0.5);
+  --overlay-bg: rgba(0, 0, 0, 0.7);
+  --toggle-bg: #3a3a3a;
+  --toggle-bg-hover: #4a4a4a;
+  
+  /* Button colors */
+  --btn-primary-bg: #0d6efd;
+  --btn-primary-bg-hover: #0a58ca;
+  --btn-primary-disabled: #555555;
+  --btn-secondary-bg: #5a6268;
+  --btn-secondary-bg-hover: #4e555b;
+  --btn-danger-bg: #bb2d3b;
+  --btn-danger-bg-hover: #9a2530;
+  
+  /* Admin colors */
+  --admin-sidebar-bg: #1a1a1a;
+  --admin-nav-hover: rgba(255, 255, 255, 0.15);
+  --admin-nav-active: #0d6efd;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 button {
@@ -40,48 +102,48 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--btn-primary-bg);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--btn-primary-bg-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--btn-primary-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--btn-secondary-bg);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--btn-secondary-bg-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--btn-danger-bg);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--btn-danger-bg-hover);
 }
 
 .card {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--shadow-color);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.3s ease;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--shadow-color-hover);
 }
 
 .modal-overlay {
@@ -90,7 +152,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-bg);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +160,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +176,26 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  transition: border-color 0.2s, background-color 0.3s ease;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--btn-primary-bg);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--btn-danger-bg);
   font-size: 14px;
   margin-top: 4px;
 }


### PR DESCRIPTION
## Summary

Implements dark mode for the web UI as requested in [crafting-demo/demo-shop#25](https://github.com/crafting-demo/demo-shop/issues/25).

## Changes Made

### Core Theme Infrastructure
- **ThemeContext & ThemeProvider**: Created a React context for managing theme state across the application
- **ThemeToggle Component**: Built a reusable toggle button component with moon/sun icons
- **LocalStorage Integration**: Theme preference is automatically saved and restored on page load

### CSS Architecture
- **CSS Variables**: Implemented comprehensive CSS custom properties for all colors
  - Light mode: Clean, professional color palette
  - Dark mode: Eye-friendly dark grays with appropriate contrast
- **Smooth Transitions**: Added 0.3s transitions for seamless theme switching

### Customer Interface Updates
- ✅ Landing Page: Header with theme toggle, product grid with proper contrast
- ✅ Product Page: Modal with themed backgrounds and text
- ✅ Checkout Page: Cart items and summary with dark mode support
- ✅ Payment Page: Form inputs styled for both themes
- ✅ Thank You Page: Success message with proper theming

### Admin Interface Updates
- ✅ Admin Panel: Sidebar with theme toggle, proper contrast for navigation
- ✅ Inventory Page: Data table with themed rows, badges, and actions
- ✅ Product Edit: Form elements with dark mode styling
- ✅ Orders Page: Order table with status badges optimized for both themes

## Testing

Tested in sandbox `ai-7b9c2e8f4a13d6b5` using template `demo-shop`:

### Build Verification
- ✅ TypeScript compilation successful
- ✅ Vite build completed without errors
- ✅ All assets generated correctly

### Functionality Checks
- ✅ Customer app loads successfully at https://app--ai-7b9c2e8f4a13d6b5-demo.crafting.site.sandboxes.run
- ✅ Theme toggle switches between light and dark modes
- ✅ Theme preference persists across page refreshes (localStorage)
- ✅ All pages render correctly in both themes
- ✅ Buttons, forms, and interactive elements maintain proper contrast
- ✅ Status badges (available, off-shelf, order states) are readable in dark mode

## Accessibility
- Theme toggle has proper `aria-label` and `title` attributes
- Sufficient color contrast in both light and dark modes
- Minimum touch target size (44x44px) for the toggle button

## Technical Details
- No breaking changes
- No new dependencies required
- Backward compatible with existing code
- Theme defaults to light mode if no preference is stored

Fixes #25

---

**Sandbox**: ai-7b9c2e8f4a13d6b5  
**Template**: demo-shop