### PR TITLE
feat: implement dark mode in Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -8,12 +8,27 @@
   background: #2c3e50;
   color: white;
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  flex-shrink: 0;
+}
+
+[data-theme='dark'] .sidebar {
+  background: #1a252f;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
 }
 
 .sidebar h1 {
   font-size: 24px;
-  margin-bottom: 32px;
   color: white;
+  margin-bottom: 0;
 }
 
 .sidebar nav {
@@ -40,8 +55,14 @@
   background: #3498db;
 }
 
+[data-theme='dark'] .nav-item.active {
+  background: #2980b9;
+}
+
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background: var(--color-bg);
+  transition: background-color 0.2s;
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import DarkModeToggle from '../shared/DarkModeToggle';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -36,7 +37,10 @@ const AdminApp: React.FC = () => {
   return (
     <div className="admin-app">
       <div className="sidebar">
-        <h1>Admin Panel</h1>
+        <div className="sidebar-header">
+          <h1>Admin Panel</h1>
+          <DarkModeToggle />
+        </div>
         <nav>
           <button
             className={`nav-item ${currentTab === 'inventory' ? 'active' : ''}`}

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +25,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +53,19 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-table-header-bg);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-table-header-bg);
 }
 
 .col-image img {
@@ -73,17 +77,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .state-badge {
@@ -94,13 +98,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-off-shelf-bg);
+  color: var(--color-badge-off-shelf-text);
 }
 
 .col-actions {
@@ -108,26 +112,27 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-surface-raised);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +142,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .action-menu button:last-child {
@@ -148,7 +153,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-table-header-bg);
 }
 
 .pagination {
@@ -161,21 +166,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,17 @@
 .order-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
+}
+
+.order-admin .page-header h1 {
+  font-size: 28px;
+  color: var(--color-text-primary);
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +26,62 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-table-header-bg);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-table-header-bg);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -20,7 +20,10 @@
 }
 
 .edit-form {
+  background: var(--color-surface);
+  border-radius: 8px;
   padding: 32px;
+  transition: background-color 0.2s;
 }
 
 .form-section {
@@ -29,10 +32,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-light);
 }
 
 .form-row {
@@ -60,5 +63,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-light);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -2,6 +2,29 @@
   min-height: 100vh;
 }
 
+.checkout-header {
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.checkout-header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
+.checkout-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .empty-cart {
   text-align: center;
   padding: 60px 20px;
@@ -9,7 +32,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +63,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +82,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-surface-raised);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +102,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +113,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .cart-summary {
@@ -99,7 +124,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +133,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.tsx
+++ b/src/ts/web/src/customer/pages/CheckoutPage.tsx
@@ -9,6 +9,7 @@ import {
   RemoveFromCartMutationVariables,
 } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import DarkModeToggle from '../../shared/DarkModeToggle';
 import './CheckoutPage.css';
 
 interface CheckoutPageProps {
@@ -50,12 +51,14 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
 
   return (
     <div className="checkout-page">
-      <header className="header">
+      <header className="checkout-header">
         <button className="btn btn-secondary" onClick={onBack}>
           ← Back
         </button>
         <h1>Shopping Cart</h1>
-        <div></div>
+        <div className="checkout-header-actions">
+          <DarkModeToggle />
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,23 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.2s;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +39,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .cart-icon {
@@ -40,7 +47,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +81,26 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  color: var(--color-text-secondary);
+  text-align: center;
+  padding: 40px 0;
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import DarkModeToggle from '../../shared/DarkModeToggle';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -60,12 +61,15 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <DarkModeToggle />
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -2,6 +2,29 @@
   min-height: 100vh;
 }
 
+.payment-header {
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.payment-header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
+.payment-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .payment-form {
   max-width: 600px;
   margin: 0 auto;
@@ -10,24 +33,26 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-payment-summary-bg);
   border-radius: 8px;
+  transition: background-color 0.2s;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--color-text-primary);
 }
 
 .summary-row {
@@ -39,7 +64,7 @@
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.tsx
+++ b/src/ts/web/src/customer/pages/PaymentPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { PLACE_ORDER } from '../queries';
 import { PlaceOrderMutation, PlaceOrderMutationVariables } from '../../generated/graphql';
+import DarkModeToggle from '../../shared/DarkModeToggle';
 import './PaymentPage.css';
 
 interface PaymentPageProps {
@@ -84,12 +85,14 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
 
   return (
     <div className="payment-page">
-      <header className="header">
+      <header className="payment-header">
         <button className="btn btn-secondary" onClick={onBack}>
           ← Back
         </button>
         <h1>Payment</h1>
-        <div></div>
+        <div className="payment-header-actions">
+          <DarkModeToggle />
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-surface-raised);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/DarkModeToggle.css
+++ b/src/ts/web/src/shared/DarkModeToggle.css
@@ -1,0 +1,18 @@
+.dark-mode-toggle {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  flex-shrink: 0;
+}
+
+.dark-mode-toggle:hover {
+  background: var(--color-surface-hover);
+}

--- a/src/ts/web/src/shared/DarkModeToggle.tsx
+++ b/src/ts/web/src/shared/DarkModeToggle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTheme } from './ThemeContext';
+import './DarkModeToggle.css';
+
+const DarkModeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      className="dark-mode-toggle"
+      onClick={toggleTheme}
+      aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {theme === 'dark' ? '☀️' : '🌙'}
+    </button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,90 @@
+/* ── Design tokens ──────────────────────────────────────────── */
+:root {
+  /* Light mode (default) */
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-raised: #f5f5f5;
+  --color-surface-hover: #e0e0e0;
+  --color-border: #dddddd;
+  --color-border-light: #eeeeee;
+
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+
+  --color-accent: #007bff;
+  --color-accent-hover: #0056b3;
+  --color-accent-disabled: #cccccc;
+
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-success: #28a745;
+
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-off-shelf-bg: #f8d7da;
+  --color-badge-off-shelf-text: #721c24;
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
+
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+  --color-overlay: rgba(0, 0, 0, 0.5);
+  --color-table-header-bg: #f8f9fa;
+  --color-payment-summary-bg: #f8f9fa;
+}
+
+[data-theme='dark'] {
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-raised: #2a2a2a;
+  --color-surface-hover: #3a3a3a;
+  --color-border: #3a3a3a;
+  --color-border-light: #2c2c2c;
+
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #aaaaaa;
+  --color-text-muted: #777777;
+
+  --color-accent: #4da3ff;
+  --color-accent-hover: #80bfff;
+  --color-accent-disabled: #555555;
+
+  --color-danger: #ff6b6b;
+  --color-danger-hover: #ff4040;
+  --color-secondary: #9e9e9e;
+  --color-secondary-hover: #bdbdbd;
+  --color-success: #4caf50;
+
+  --color-badge-available-bg: #1b3a24;
+  --color-badge-available-text: #81c784;
+  --color-badge-off-shelf-bg: #3b1a1d;
+  --color-badge-off-shelf-text: #ef9a9a;
+  --color-badge-processing-bg: #3b3010;
+  --color-badge-processing-text: #ffe082;
+  --color-badge-shipped-bg: #102a3b;
+  --color-badge-shipped-text: #90caf9;
+  --color-badge-completed-bg: #1b3a24;
+  --color-badge-completed-text: #81c784;
+  --color-badge-canceled-bg: #3b1a1d;
+  --color-badge-canceled-text: #ef9a9a;
+
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-shadow-hover: rgba(0, 0, 0, 0.6);
+  --color-overlay: rgba(0, 0, 0, 0.75);
+  --color-table-header-bg: #252525;
+  --color-payment-summary-bg: #252525;
+}
+
+/* ── Reset ──────────────────────────────────────────────────── */
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +97,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -25,12 +114,14 @@ input, textarea {
   outline: none;
 }
 
+/* ── Layout ─────────────────────────────────────────────────── */
 .container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
 }
 
+/* ── Buttons ────────────────────────────────────────────────── */
 .btn {
   padding: 12px 24px;
   border-radius: 4px;
@@ -40,57 +131,59 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-accent);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-accent-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
+/* ── Cards ──────────────────────────────────────────────────── */
 .card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
+/* ── Modal ──────────────────────────────────────────────────── */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +191,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -106,6 +199,7 @@ input, textarea {
   padding: 24px;
 }
 
+/* ── Forms ──────────────────────────────────────────────────── */
 .form-group {
   margin-bottom: 16px;
 }
@@ -114,23 +208,33 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s, background-color 0.2s;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-accent);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* ── Select ─────────────────────────────────────────────────── */
+select {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
 }


### PR DESCRIPTION
## Summary

Implements dark mode support across the entire Web UI (both customer-facing shop and admin panel).

Closes #41
[crafting\-demo/demo\-shop\#41](https://github.com/crafting-demo/demo-shop/issues/41)

## Changes

### New files
- `src/ts/web/src/shared/ThemeContext.tsx` — React context providing `theme` state and `toggleTheme`. Initializes from `localStorage` (persisted preference) with fallback to `prefers-color-scheme` system setting.
- `src/ts/web/src/shared/DarkModeToggle.tsx` — Reusable toggle button component (🌙/☀️) with accessible `aria-label`.
- `src/ts/web/src/shared/DarkModeToggle.css` — Styles for the toggle button using CSS variables.

### Modified files
- `src/ts/web/src/shared/styles.css` — Refactored to use CSS custom properties (`--color-*`). Added full `:root` (light) token set and `[data-theme='dark']` override block covering all colors (backgrounds, surfaces, text, accents, badges, shadows, etc.).
- All page CSS files updated to reference CSS variables instead of hardcoded colors.
- `LandingPage.tsx` / `CheckoutPage.tsx` / `PaymentPage.tsx` — `DarkModeToggle` added to each page header.
- `AdminApp.tsx` — `DarkModeToggle` added to the sidebar header.
- `customer/index.tsx` / `admin/index.tsx` — Entry points wrapped with `ThemeProvider`.

## How it works

1. On load, `ThemeProvider` reads `localStorage.theme` (if set) or detects `prefers-color-scheme`.
2. It sets `data-theme` attribute on `<html>` and saves choice back to `localStorage`.
3. CSS custom properties switch automatically based on `[data-theme='dark']`.
4. Any page header contains the toggle button so the user can switch at any time.

## Testing

- `npm run type-check` — passes (strict TypeScript, no errors)
- `npm run build` — passes cleanly (Vite production build, all 343 modules transformed)

## Sandbox & Template

- Sandbox: `ai-b3f92e1a7c04d581`
- Template: `demo-shop`