### PR TITLE
feat: implement dark mode for web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,9 +5,10 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
+  background: var(--color-sidebar-bg);
   color: white;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .sidebar h1 {
@@ -20,6 +21,19 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.sidebar .dark-mode-toggle {
+  margin-top: 24px;
+  border-color: rgba(255, 255, 255, 0.3);
+  color: white;
+  width: 100%;
+  justify-content: center;
+}
+
+.sidebar .dark-mode-toggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.6);
 }
 
 .nav-item {
@@ -37,11 +51,13 @@
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--color-sidebar-active);
 }
 
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background-color: var(--color-bg-primary);
+  transition: background-color 0.3s ease;
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import DarkModeToggle from '../shared/DarkModeToggle';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -57,6 +58,7 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <DarkModeToggle />
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +25,21 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, border-color 0.2s;
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +54,21 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-muted);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.3s ease;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-surface-hover);
 }
 
 .col-image img {
@@ -73,17 +80,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .state-badge {
@@ -94,13 +101,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-offshelf-bg);
+  color: var(--color-badge-offshelf-text);
 }
 
 .col-actions {
@@ -108,26 +115,27 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-action-btn-bg);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-action-btn-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +145,11 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  transition: background-color 0.2s;
 }
 
 .action-menu button:last-child {
@@ -148,7 +157,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-surface-hover);
 }
 
 .pagination {
@@ -161,21 +170,22 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   border-radius: 4px;
+  transition: background-color 0.2s;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +21,64 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-muted);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.3s ease;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-surface-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -1,5 +1,8 @@
 .product-edit {
   max-width: 800px;
+  background: var(--color-bg-surface);
+  border-radius: 8px;
+  transition: background-color 0.3s ease;
 }
 
 .page-header {
@@ -11,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -29,10 +32,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-light);
 }
 
 .form-row {
@@ -56,9 +59,10 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  color: var(--color-text-primary);
 }
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-light);
 }

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-quantity-btn-bg);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-quantity-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +79,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +90,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .cart-summary {
@@ -99,7 +101,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +110,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-bg-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,24 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  gap: 12px;
+  transition: background-color 0.3s ease;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -29,10 +37,11 @@
   align-items: center;
   gap: 8px;
   font-size: 18px;
+  transition: background-color 0.2s;
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .cart-icon {
@@ -40,7 +49,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +83,20 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import DarkModeToggle from '../../shared/DarkModeToggle';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -60,12 +61,15 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <DarkModeToggle />
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,36 +10,39 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-payment-summary-bg);
   border-radius: 8px;
+  transition: background-color 0.3s ease;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--color-text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-close-btn-bg);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,13 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
+  transition: background-color 0.2s;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-close-btn-hover);
 }
 
 .product-detail {
@@ -51,12 +52,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +70,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/DarkModeToggle.tsx
+++ b/src/ts/web/src/shared/DarkModeToggle.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useDarkMode } from './useDarkMode';
+
+interface DarkModeToggleProps {
+  className?: string;
+}
+
+const DarkModeToggle: React.FC<DarkModeToggleProps> = ({ className }) => {
+  const { isDark, toggle } = useDarkMode();
+
+  return (
+    <button
+      className={`dark-mode-toggle${className ? ` ${className}` : ''}`}
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      <span>{isDark ? '☀️' : '🌙'}</span>
+      <span className="toggle-label">{isDark ? 'Light' : 'Dark'}</span>
+    </button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,178 @@
+/* CSS custom properties for theming */
+:root {
+  --color-bg-primary: #f5f5f5;
+  --color-bg-surface: #ffffff;
+  --color-bg-surface-hover: #f8f9fa;
+  --color-bg-muted: #f8f9fa;
+  --color-bg-overlay: rgba(0, 0, 0, 0.5);
+
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+
+  --color-border: #dddddd;
+  --color-border-light: #eeeeee;
+
+  --color-accent: #007bff;
+  --color-accent-hover: #0056b3;
+  --color-accent-disabled: #cccccc;
+
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+
+  --color-success: #28a745;
+
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+
+  --color-sidebar-bg: #2c3e50;
+  --color-sidebar-active: #3498db;
+
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-offshelf-bg: #f8d7da;
+  --color-badge-offshelf-text: #721c24;
+
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
+
+  --color-quantity-btn-bg: #f5f5f5;
+  --color-quantity-btn-hover: #e0e0e0;
+  --color-close-btn-bg: #f5f5f5;
+  --color-close-btn-hover: #e0e0e0;
+  --color-action-btn-bg: #f5f5f5;
+  --color-action-btn-hover: #e0e0e0;
+
+  --color-input-bg: #ffffff;
+  --color-payment-summary-bg: #f8f9fa;
+}
+
+/* Dark mode via data attribute (manual toggle) or OS preference */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg-primary: #121212;
+    --color-bg-surface: #1e1e1e;
+    --color-bg-surface-hover: #2a2a2a;
+    --color-bg-muted: #252525;
+    --color-bg-overlay: rgba(0, 0, 0, 0.7);
+
+    --color-text-primary: #e0e0e0;
+    --color-text-secondary: #aaaaaa;
+    --color-text-muted: #777777;
+
+    --color-border: #3a3a3a;
+    --color-border-light: #2e2e2e;
+
+    --color-accent: #4da3ff;
+    --color-accent-hover: #1a7ddb;
+    --color-accent-disabled: #555555;
+
+    --color-secondary: #8a9199;
+    --color-secondary-hover: #6c757d;
+
+    --color-danger: #f06070;
+    --color-danger-hover: #d94455;
+
+    --color-success: #4caf70;
+
+    --color-shadow: rgba(0, 0, 0, 0.4);
+    --color-shadow-hover: rgba(0, 0, 0, 0.5);
+
+    --color-sidebar-bg: #1a252f;
+    --color-sidebar-active: #2176ae;
+
+    --color-badge-available-bg: #1a3a24;
+    --color-badge-available-text: #6fcf97;
+    --color-badge-offshelf-bg: #3a1a1e;
+    --color-badge-offshelf-text: #f06070;
+
+    --color-badge-processing-bg: #3a3010;
+    --color-badge-processing-text: #f0c040;
+    --color-badge-shipped-bg: #102040;
+    --color-badge-shipped-text: #70b0ef;
+    --color-badge-completed-bg: #1a3a24;
+    --color-badge-completed-text: #6fcf97;
+    --color-badge-canceled-bg: #3a1a1e;
+    --color-badge-canceled-text: #f06070;
+
+    --color-quantity-btn-bg: #2e2e2e;
+    --color-quantity-btn-hover: #3e3e3e;
+    --color-close-btn-bg: #2e2e2e;
+    --color-close-btn-hover: #3e3e3e;
+    --color-action-btn-bg: #2e2e2e;
+    --color-action-btn-hover: #3e3e3e;
+
+    --color-input-bg: #2a2a2a;
+    --color-payment-summary-bg: #252525;
+  }
+}
+
+[data-theme="dark"] {
+  --color-bg-primary: #121212;
+  --color-bg-surface: #1e1e1e;
+  --color-bg-surface-hover: #2a2a2a;
+  --color-bg-muted: #252525;
+  --color-bg-overlay: rgba(0, 0, 0, 0.7);
+
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #aaaaaa;
+  --color-text-muted: #777777;
+
+  --color-border: #3a3a3a;
+  --color-border-light: #2e2e2e;
+
+  --color-accent: #4da3ff;
+  --color-accent-hover: #1a7ddb;
+  --color-accent-disabled: #555555;
+
+  --color-secondary: #8a9199;
+  --color-secondary-hover: #6c757d;
+
+  --color-danger: #f06070;
+  --color-danger-hover: #d94455;
+
+  --color-success: #4caf70;
+
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-shadow-hover: rgba(0, 0, 0, 0.5);
+
+  --color-sidebar-bg: #1a252f;
+  --color-sidebar-active: #2176ae;
+
+  --color-badge-available-bg: #1a3a24;
+  --color-badge-available-text: #6fcf97;
+  --color-badge-offshelf-bg: #3a1a1e;
+  --color-badge-offshelf-text: #f06070;
+
+  --color-badge-processing-bg: #3a3010;
+  --color-badge-processing-text: #f0c040;
+  --color-badge-shipped-bg: #102040;
+  --color-badge-shipped-text: #70b0ef;
+  --color-badge-completed-bg: #1a3a24;
+  --color-badge-completed-text: #6fcf97;
+  --color-badge-canceled-bg: #3a1a1e;
+  --color-badge-canceled-text: #f06070;
+
+  --color-quantity-btn-bg: #2e2e2e;
+  --color-quantity-btn-hover: #3e3e3e;
+  --color-close-btn-bg: #2e2e2e;
+  --color-close-btn-hover: #3e3e3e;
+  --color-action-btn-bg: #2e2e2e;
+  --color-action-btn-hover: #3e3e3e;
+
+  --color-input-bg: #2a2a2a;
+  --color-payment-summary-bg: #252525;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +185,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 button {
@@ -40,48 +217,48 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-accent);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-accent-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
 .card {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.3s ease;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
 .modal-overlay {
@@ -90,7 +267,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-bg-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +275,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +291,52 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s, background-color 0.3s ease;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-accent);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* Dark mode toggle button */
+.dark-mode-toggle {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 18px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background-color 0.2s, border-color 0.2s;
+  white-space: nowrap;
+}
+
+.dark-mode-toggle:hover {
+  background: var(--color-bg-surface-hover);
+  border-color: var(--color-accent);
+}
+
+.dark-mode-toggle .toggle-label {
+  font-size: 13px;
+  font-weight: 500;
 }

--- a/src/ts/web/src/shared/useDarkMode.ts
+++ b/src/ts/web/src/shared/useDarkMode.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'demo-shop-theme';
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  if (theme === 'system') {
+    root.removeAttribute('data-theme');
+  } else {
+    root.setAttribute('data-theme', theme);
+  }
+}
+
+export function useDarkMode() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? 'system';
+  });
+
+  const isDark =
+    theme === 'dark' || (theme === 'system' && getSystemTheme() === 'dark');
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  // Keep in sync with OS preference changes when in system mode
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      if (theme === 'system') {
+        applyTheme('system');
+      }
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  const toggle = () => {
+    setTheme(prev => {
+      if (prev === 'system') return getSystemTheme() === 'dark' ? 'light' : 'dark';
+      return prev === 'dark' ? 'light' : 'dark';
+    });
+  };
+
+  return { theme, isDark, toggle };
+}


### PR DESCRIPTION
## Summary

Implements dark mode for the demo-shop web UI, addressing [crafting\-demo/demo\-shop\#45](https://github.com/crafting-demo/demo-shop/issues/45).

Closes #45

## Changes

### New Files
- `src/ts/web/src/shared/useDarkMode.ts` — Custom React hook for theme state management (light/dark/system modes), persists preference in `localStorage`, syncs with OS preference changes via `matchMedia`
- `src/ts/web/src/shared/DarkModeToggle.tsx` — Toggle button component with ☀️/🌙 icons, placed in the shop header and admin sidebar

### Modified Files
- `src/ts/web/src/shared/styles.css` — Refactored to use CSS custom properties (design tokens) for all colors; defines light theme in `:root`, dark theme in `[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` (respects OS preference unless overridden)
- All customer and admin CSS files updated to use CSS variables
- `src/ts/web/src/customer/pages/LandingPage.tsx` — Added `DarkModeToggle` to the shop header
- `src/ts/web/src/admin/AdminApp.tsx` — Added `DarkModeToggle` to the admin sidebar

## Features
- **Manual toggle**: Click sun/moon button to switch between light and dark modes
- **OS preference**: Automatically follows system dark/light mode preference by default
- **Persistent**: User preference saved in `localStorage` across browser sessions
- **Smooth transitions**: 0.3s ease transitions for all theme color changes
- **Both UIs**: Available in both the customer shop and the admin panel

## Test Results
- ✅ TypeScript compilation passed (`tsc`)
- ✅ Vite production build succeeded with no warnings
- ✅ All 342 modules transformed cleanly

## Sandbox & Template
- **Sandbox**: `ai-3f8c2a1d9e4b7f05`
- **Template**: `demo-shop`