### PR TITLE
feat: implement light/dark mode theme toggle in web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,15 +5,16 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
-  color: white;
+  background: var(--color-sidebar-bg);
+  color: var(--color-sidebar-text);
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .sidebar h1 {
   font-size: 24px;
   margin-bottom: 32px;
-  color: white;
+  color: var(--color-sidebar-text);
 }
 
 .sidebar nav {
@@ -25,7 +26,7 @@
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: white;
+  color: var(--color-sidebar-text);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -33,15 +34,41 @@
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--color-sidebar-hover);
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--color-sidebar-active);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.sidebar-theme-toggle {
+  background: var(--color-sidebar-hover);
+  color: var(--color-sidebar-text);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  padding: 8px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  transition: background-color 0.2s;
+}
+
+.sidebar-theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background-color: var(--color-bg);
+  transition: background-color 0.3s ease;
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import { useTheme } from '../shared/ThemeContext';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -57,6 +59,11 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <div className="sidebar-footer">
+          <button className="sidebar-theme-toggle" onClick={toggleTheme} title="Toggle theme">
+            {theme === 'light' ? '🌙 Dark Mode' : '☀️ Light Mode'}
+          </button>
+        </div>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +25,21 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +54,20 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-secondary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.3s ease;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .col-image img {
@@ -73,17 +79,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .state-badge {
@@ -94,13 +100,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-offshelf-bg);
+  color: var(--color-badge-offshelf-text);
 }
 
 .col-actions {
@@ -108,28 +114,30 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-action-btn-bg);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-action-btn-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
+  transition: background-color 0.3s ease;
 }
 
 .action-menu button {
@@ -137,10 +145,11 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  transition: background-color 0.2s;
 }
 
 .action-menu button:last-child {
@@ -148,7 +157,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .pagination {
@@ -161,21 +170,22 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   border-radius: 4px;
+  transition: background-color 0.2s;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.3s ease;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +21,63 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-secondary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.3s ease;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -20,7 +20,10 @@
 }
 
 .edit-form {
+  background: var(--color-surface);
+  border-radius: 8px;
   padding: 32px;
+  transition: background-color 0.3s ease;
 }
 
 .form-section {
@@ -29,10 +32,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-light);
 }
 
 .form-row {
@@ -60,5 +63,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-light);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-quantity-btn-bg);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-quantity-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +79,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +90,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .cart-summary {
@@ -99,7 +101,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +110,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.tsx
+++ b/src/ts/web/src/customer/pages/CheckoutPage.tsx
@@ -9,6 +9,7 @@ import {
   RemoveFromCartMutationVariables,
 } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './CheckoutPage.css';
 
 interface CheckoutPageProps {
@@ -24,6 +25,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
   onCheckout,
   onBack,
 }) => {
+  const { theme, toggleTheme } = useTheme();
   const [updateCartItem] = useMutation<UpdateCartItemMutation, UpdateCartItemMutationVariables>(
     UPDATE_CART_ITEM
   );
@@ -55,7 +57,9 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
           ← Back
         </button>
         <h1>Shopping Cart</h1>
-        <div></div>
+        <button className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
+          {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+        </button>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,23 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +39,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .cart-icon {
@@ -40,7 +47,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +81,26 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--color-text-secondary);
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -18,6 +19,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
   onCartClick,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const { data, loading, fetchMore } = useQuery<GetProductsQuery, GetProductsQueryVariables>(
     GET_PRODUCTS,
@@ -60,12 +62,17 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
+            {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+          </button>
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,36 +10,39 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-payment-summary-bg);
   border-radius: 8px;
+  transition: background-color 0.3s ease;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--color-text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.tsx
+++ b/src/ts/web/src/customer/pages/PaymentPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { PLACE_ORDER } from '../queries';
 import { PlaceOrderMutation, PlaceOrderMutationVariables } from '../../generated/graphql';
+import { useTheme } from '../../shared/ThemeContext';
 import './PaymentPage.css';
 
 interface PaymentPageProps {
@@ -21,6 +22,7 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
   onPlaceOrder,
   onBack,
 }) => {
+  const { theme, toggleTheme } = useTheme();
   const [customerInfo, setCustomerInfo] = useState<CustomerInfo>({
     name: '',
     email: '',
@@ -89,7 +91,9 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
           ← Back
         </button>
         <h1>Payment</h1>
-        <div></div>
+        <button className="theme-toggle" onClick={toggleTheme} title="Toggle theme">
+          {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+        </button>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-close-btn-bg);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,13 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
+  transition: background-color 0.2s;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-close-btn-hover);
 }
 
 .product-detail {
@@ -51,12 +52,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +70,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    // Default to light mode per feature request
+    return 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,98 @@
+/* Light mode (default) */
+:root,
+[data-theme="light"] {
+  --color-bg: #f5f5f5;
+  --color-bg-secondary: #f8f9fa;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f8f9fa;
+  --color-border: #ddd;
+  --color-border-light: #eee;
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+  --color-accent: #007bff;
+  --color-accent-hover: #0056b3;
+  --color-accent-disabled: #ccc;
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-success: #28a745;
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+  --color-overlay: rgba(0, 0, 0, 0.5);
+  --color-sidebar-bg: #2c3e50;
+  --color-sidebar-text: #ffffff;
+  --color-sidebar-active: #3498db;
+  --color-sidebar-hover: rgba(255, 255, 255, 0.1);
+  --color-quantity-btn-bg: #f5f5f5;
+  --color-quantity-btn-hover: #e0e0e0;
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-offshelf-bg: #f8d7da;
+  --color-badge-offshelf-text: #721c24;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-payment-summary-bg: #f8f9fa;
+  --color-close-btn-bg: #f5f5f5;
+  --color-close-btn-hover: #e0e0e0;
+  --color-action-btn-bg: #f5f5f5;
+  --color-action-btn-hover: #e0e0e0;
+}
+
+/* Dark mode */
+[data-theme="dark"] {
+  --color-bg: #1a1a2e;
+  --color-bg-secondary: #16213e;
+  --color-surface: #0f3460;
+  --color-surface-hover: #1a4a7a;
+  --color-border: #2d4a6e;
+  --color-border-light: #1e3a5f;
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #b0b8c8;
+  --color-text-muted: #8090a8;
+  --color-accent: #4da3ff;
+  --color-accent-hover: #2980ff;
+  --color-accent-disabled: #4a5568;
+  --color-danger: #ff6b7a;
+  --color-danger-hover: #e63950;
+  --color-secondary: #8090a8;
+  --color-secondary-hover: #6a7a8a;
+  --color-success: #48bb78;
+  --color-shadow: rgba(0, 0, 0, 0.3);
+  --color-shadow-hover: rgba(0, 0, 0, 0.4);
+  --color-overlay: rgba(0, 0, 0, 0.7);
+  --color-sidebar-bg: #0f1b2d;
+  --color-sidebar-text: #e0e0e0;
+  --color-sidebar-active: #4da3ff;
+  --color-sidebar-hover: rgba(255, 255, 255, 0.08);
+  --color-quantity-btn-bg: #1e3a5f;
+  --color-quantity-btn-hover: #2d4a6e;
+  --color-badge-processing-bg: #3d3010;
+  --color-badge-processing-text: #ffd04a;
+  --color-badge-shipped-bg: #0a2a4a;
+  --color-badge-shipped-text: #7ec8ff;
+  --color-badge-available-bg: #0d2d1a;
+  --color-badge-available-text: #6be09a;
+  --color-badge-offshelf-bg: #2d0d10;
+  --color-badge-offshelf-text: #ff8a94;
+  --color-badge-canceled-bg: #2d0d10;
+  --color-badge-canceled-text: #ff8a94;
+  --color-badge-completed-bg: #0d2d1a;
+  --color-badge-completed-text: #6be09a;
+  --color-payment-summary-bg: #0f3460;
+  --color-close-btn-bg: #1e3a5f;
+  --color-close-btn-hover: #2d4a6e;
+  --color-action-btn-bg: #1e3a5f;
+  --color-action-btn-hover: #2d4a6e;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +105,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 button {
@@ -40,48 +137,48 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-accent);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-accent-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
 .card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.3s ease;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
 .modal-overlay {
@@ -90,7 +187,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +195,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +211,45 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-accent);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  background: var(--color-quantity-btn-bg);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background-color 0.2s, border-color 0.3s ease;
+}
+
+.theme-toggle:hover {
+  background: var(--color-quantity-btn-hover);
 }


### PR DESCRIPTION
## Summary

Implements light mode (with dark mode toggle) in the web UI as requested in [crafting\-demo/demo\-shop\#46](https://github.com/crafting-demo/demo-shop/issues/46).

Closes #46

## Changes

### New Files
- `src/ts/web/src/shared/ThemeContext.tsx` — React context for theme state management, persists selection to `localStorage`

### Modified Files
- `src/ts/web/src/shared/styles.css` — Added comprehensive CSS custom properties (variables) for light mode (default) and dark mode; added `.theme-toggle` button styles
- `src/ts/web/src/customer/index.tsx` — Wrapped app with `ThemeProvider`
- `src/ts/web/src/admin/index.tsx` — Wrapped app with `ThemeProvider`
- `src/ts/web/src/customer/pages/LandingPage.tsx` — Added theme toggle button (🌙/☀️) to header
- `src/ts/web/src/customer/pages/CheckoutPage.tsx` — Added theme toggle button to header
- `src/ts/web/src/customer/pages/PaymentPage.tsx` — Added theme toggle button to header
- `src/ts/web/src/admin/AdminApp.tsx` — Added theme toggle button to sidebar footer
- All CSS files — Updated hardcoded colors to CSS variables

## Implementation Details

- **Default theme**: Light mode (white surfaces, light gray background)
- **Dark mode**: Deep navy/blue surfaces for contrast
- **Persistence**: Theme preference saved to `localStorage`, restored on next visit
- **Transitions**: Smooth 0.3s ease transitions for all color changes
- **Coverage**: Both customer storefront and admin panel support theming

## Testing

- TypeScript build passes: `npm run build` completed successfully with no errors
- Frontend served at the sandbox endpoints and verified running

## Sandbox & Template
- **Sandbox**: `ai-f3a9c2e1b7d05f4a`
- **Template**: `demo-shop`