### PR TITLE
feat: implement dark mode for Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,27 +5,30 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
-  color: white;
+  background: var(--bg-sidebar);
+  color: var(--text-on-dark);
   padding: 24px;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar h1 {
   font-size: 24px;
   margin-bottom: 32px;
-  color: white;
+  color: var(--text-on-dark);
 }
 
 .sidebar nav {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
 }
 
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: white;
+  color: var(--text-on-dark);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -40,8 +43,25 @@
   background: #3498db;
 }
 
+.sidebar-theme-toggle {
+  margin-top: 24px;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.1) !important;
+  color: var(--text-on-dark) !important;
+  border-radius: 8px !important;
+  padding: 10px 12px !important;
+  font-size: 14px !important;
+  justify-content: center;
+}
+
+.sidebar-theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.2) !important;
+  opacity: 1 !important;
+}
+
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background: var(--bg-primary);
 }

--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,30 +5,28 @@
 
 .sidebar {
   width: 250px;
-  background: var(--bg-sidebar);
-  color: var(--text-on-dark);
+  background: var(--color-sidebar-bg);
+  color: var(--color-sidebar-text);
   padding: 24px;
-  display: flex;
-  flex-direction: column;
+  transition: background-color 0.2s;
 }
 
 .sidebar h1 {
   font-size: 24px;
   margin-bottom: 32px;
-  color: var(--text-on-dark);
+  color: var(--color-sidebar-text);
 }
 
 .sidebar nav {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  flex: 1;
 }
 
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: var(--text-on-dark);
+  color: var(--color-sidebar-text);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -36,32 +34,32 @@
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--color-sidebar-hover);
 }
 
 .nav-item.active {
-  background: #3498db;
-}
-
-.sidebar-theme-toggle {
-  margin-top: 24px;
-  width: 100%;
-  background: rgba(255, 255, 255, 0.1) !important;
-  color: var(--text-on-dark) !important;
-  border-radius: 8px !important;
-  padding: 10px 12px !important;
-  font-size: 14px !important;
-  justify-content: center;
-}
-
-.sidebar-theme-toggle:hover {
-  background: rgba(255, 255, 255, 0.2) !important;
-  opacity: 1 !important;
+  background: var(--color-sidebar-active);
 }
 
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
-  background: var(--bg-primary);
+}
+
+/* Theme toggle inside sidebar */
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.sidebar .theme-toggle {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--color-sidebar-text);
+  width: 100%;
+  justify-content: center;
+}
+
+.sidebar .theme-toggle:hover {
+  background: var(--color-sidebar-hover);
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Product } from '../shared/types';
+import { useTheme } from '../shared/ThemeContext';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -57,6 +59,9 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <button className="theme-toggle sidebar-theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+          {theme === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode'}
+        </button>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -59,9 +59,16 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
-        <button className="theme-toggle sidebar-theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
-          {theme === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode'}
-        </button>
+        <div className="sidebar-footer">
+          <button
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            <span>{theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}</span>
+            <span className="theme-toggle-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+          </button>
+        </div>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,5 +1,5 @@
 .inventory-admin {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 24px;
 }
@@ -13,7 +13,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +24,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +52,18 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .col-image img {
@@ -73,17 +75,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .state-badge {
@@ -94,13 +96,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-available-bg);
+  color: var(--badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-offshelf-bg);
+  color: var(--badge-offshelf-text);
 }
 
 .col-actions {
@@ -108,26 +110,26 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--bg-button-muted);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--bg-button-muted-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-menu);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +139,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .action-menu button:last-child {
@@ -148,7 +150,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .pagination {
@@ -161,21 +163,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,20 +25,21 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
-  background: var(--bg-input);
-  color: var(--text-primary);
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, border-color 0.2s;
 }
 
 .inventory-table {
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -52,18 +54,19 @@
 }
 
 .table-header {
-  background: var(--bg-tertiary);
+  background: var(--color-surface-alt);
   font-weight: 600;
-  color: var(--text-primary);
-  border-bottom: 2px solid var(--border-color);
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .table-row {
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .table-row:hover {
-  background: var(--bg-hover);
+  background: var(--color-surface-alt);
 }
 
 .col-image img {
@@ -75,17 +78,17 @@
 
 .col-id {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .state-badge {
@@ -96,13 +99,13 @@
 }
 
 .state-badge.available {
-  background: var(--badge-available-bg);
-  color: var(--badge-available-text);
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: var(--badge-offshelf-bg);
-  color: var(--badge-offshelf-text);
+  background: var(--color-badge-off-shelf-bg);
+  color: var(--color-badge-off-shelf-text);
 }
 
 .col-actions {
@@ -110,26 +113,27 @@
 }
 
 .action-button {
-  background: var(--bg-button-muted);
+  background: var(--color-btn-qty-bg);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: var(--bg-button-muted-hover);
+  background: var(--color-btn-qty-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: var(--shadow-menu);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
 }
@@ -139,10 +143,11 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: var(--bg-secondary);
-  color: var(--text-primary);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--color-border-light);
+  transition: background-color 0.2s;
 }
 
 .action-menu button:last-child {
@@ -150,7 +155,7 @@
 }
 
 .action-menu button:hover {
-  background: var(--bg-hover);
+  background: var(--color-surface-alt);
 }
 
 .pagination {
@@ -163,21 +168,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: var(--color-primary);
+  background: var(--color-accent);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: var(--color-disabled);
+  background: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: var(--color-primary-hover);
+  background: var(--color-accent-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .order-table {
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,61 +21,62 @@
 }
 
 .order-table .table-header {
-  background: var(--bg-tertiary);
+  background: var(--color-surface-alt);
   font-weight: 600;
-  color: var(--text-primary);
-  border-bottom: 2px solid var(--border-color);
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .order-table .table-row:hover {
-  background: var(--bg-hover);
+  background: var(--color-surface-alt);
 }
 
 .col-id {
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .col-customer {
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: var(--badge-processing-bg);
-  color: var(--badge-processing-text);
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: var(--badge-shipped-bg);
-  color: var(--badge-shipped-text);
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: var(--badge-completed-bg);
-  color: var(--badge-completed-text);
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: var(--badge-canceled-bg);
-  color: var(--badge-canceled-text);
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,11 @@
 .order-admin {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 24px;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +20,61 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--badge-processing-bg);
+  color: var(--badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--badge-shipped-bg);
+  color: var(--badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-completed-bg);
+  color: var(--badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-canceled-bg);
+  color: var(--badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .header-actions {
@@ -20,6 +20,8 @@
 }
 
 .edit-form {
+  background: var(--bg-secondary);
+  border-radius: 8px;
   padding: 32px;
 }
 
@@ -29,10 +31,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--border-light);
 }
 
 .form-row {
@@ -56,9 +58,10 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  color: var(--text-primary);
 }
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--border-light);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -20,9 +20,10 @@
 }
 
 .edit-form {
-  background: var(--bg-secondary);
-  border-radius: 8px;
   padding: 32px;
+  background: var(--color-surface);
+  border-radius: 8px;
+  transition: background-color 0.2s;
 }
 
 .form-section {
@@ -31,10 +32,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid var(--border-light);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .form-row {
@@ -58,10 +59,10 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid var(--border-light);
+  border-top: 2px solid var(--color-border);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,13 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: var(--bg-quantity-btn);
+  background: var(--color-btn-qty-bg);
   font-size: 18px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: var(--bg-quantity-btn-hover);
+  background: var(--color-btn-qty-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,7 +78,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -89,7 +89,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .cart-summary {
@@ -100,7 +100,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -109,14 +109,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid var(--border-light);
-  color: var(--text-primary);
+  border-top: 1px solid var(--color-border-light);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,13 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--bg-quantity-btn);
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--bg-quantity-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +78,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--text-primary);
 }
 
 .item-total {
@@ -88,7 +89,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .cart-summary {
@@ -99,7 +100,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +109,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--border-light);
+  color: var(--text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-header);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -16,13 +16,19 @@
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
-  color: white;
+  background: var(--color-primary);
+  color: var(--text-on-primary);
   padding: 10px 16px;
   border-radius: 20px;
   display: flex;
@@ -32,7 +38,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .cart-icon {
@@ -40,7 +46,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +80,20 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: var(--bg-secondary);
-  box-shadow: var(--shadow-header);
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,14 +12,21 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.2s;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .header h1 {
   font-size: 24px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
-.header-controls {
+.header-actions {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -27,8 +34,8 @@
 
 .cart-button {
   position: relative;
-  background: var(--color-primary);
-  color: var(--text-on-primary);
+  background: var(--color-accent);
+  color: white;
   padding: 10px 16px;
   border-radius: 20px;
   display: flex;
@@ -38,7 +45,7 @@
 }
 
 .cart-button:hover {
-  background: var(--color-primary-hover);
+  background: var(--color-accent-hover);
 }
 
 .cart-icon {
@@ -80,20 +87,27 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: var(--color-primary);
+  color: var(--color-accent);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  text-align: center;
+  padding: 48px;
+  color: var(--color-text-secondary);
+  font-size: 18px;
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -61,13 +61,20 @@ const LandingPage: React.FC<LandingPageProps> = ({
   return (
     <div className="landing-page">
       <header className="header">
-        <h1>Shop</h1>
-        <div className="header-controls">
-          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
-            {theme === 'dark' ? '☀️' : '🌙'}
+        <div className="header-left">
+          <h1>Shop</h1>
+        </div>
+        <div className="header-actions">
+          <button
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          >
+            <span>{theme === 'dark' ? '\u2600\uFE0F' : '\uD83C\uDF19'}</span>
+            <span className="theme-toggle-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
           </button>
           <button className="cart-button" onClick={onCartClick}>
-            <span className="cart-icon">🛒</span>
+            <span className="cart-icon">\uD83D\uDED2</span>
             {cartItemCount > 0 && (
               <span className="cart-badge">{cartItemCount}</span>
             )}

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -18,6 +19,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
   onCartClick,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const { data, loading, fetchMore } = useQuery<GetProductsQuery, GetProductsQueryVariables>(
     GET_PRODUCTS,
@@ -60,12 +62,17 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-controls">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+            {theme === 'dark' ? '☀️' : '🌙'}
+          </button>
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,7 +10,7 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
@@ -21,27 +21,28 @@
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: var(--bg-tertiary);
+  background: var(--color-surface-alt);
   border-radius: 8px;
+  border: 1px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: var(--text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,36 +10,38 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--bg-tertiary);
   border-radius: 8px;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: var(--bg-button-muted);
+  background: var(--color-btn-qty-bg);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: var(--bg-button-muted-hover);
+  background: var(--color-btn-qty-hover);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--bg-button-muted);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--bg-button-muted-hover);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -12,10 +12,13 @@ const ThemeContext = createContext<ThemeContextValue>({
   toggleTheme: () => {},
 });
 
+export const useTheme = () => useContext(ThemeContext);
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>(() => {
+    // Persist preference in localStorage; fall back to system preference
     const stored = localStorage.getItem('theme') as Theme | null;
-    if (stored === 'dark' || stored === 'light') return stored;
+    if (stored === 'light' || stored === 'dark') return stored;
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
@@ -24,7 +27,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
@@ -32,5 +35,3 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     </ThemeContext.Provider>
   );
 };
-
-export const useTheme = () => useContext(ThemeContext);

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'dark' || stored === 'light') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,111 +1,94 @@
-/* CSS custom properties for theming */
+/* ── Light theme (default) ── */
 :root,
 [data-theme="light"] {
-  --bg-primary: #f5f5f5;
-  --bg-secondary: #ffffff;
-  --bg-tertiary: #f8f9fa;
-  --bg-hover: #f8f9fa;
-  --bg-input: #ffffff;
-  --bg-sidebar: #2c3e50;
-  --bg-button-muted: #f5f5f5;
-  --bg-button-muted-hover: #e0e0e0;
-  --bg-quantity-btn: #f5f5f5;
-  --bg-quantity-btn-hover: #e0e0e0;
-
-  --text-primary: #333333;
-  --text-secondary: #666666;
-  --text-muted: #999999;
-  --text-on-dark: #ffffff;
-  --text-on-primary: #ffffff;
-
-  --border-color: #dddddd;
-  --border-light: #eeeeee;
-  --border-form: #dddddd;
-  --border-focus: #007bff;
-
-  --shadow-card: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.15);
-  --shadow-header: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --shadow-menu: 0 4px 8px rgba(0, 0, 0, 0.1);
-
-  --color-primary: #007bff;
-  --color-primary-hover: #0056b3;
-  --color-secondary: #6c757d;
-  --color-secondary-hover: #545b62;
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f8f9fa;
+  --color-border: #dddddd;
+  --color-border-light: #eeeeee;
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+  --color-accent: #007bff;
+  --color-accent-hover: #0056b3;
+  --color-accent-disabled: #cccccc;
   --color-danger: #dc3545;
   --color-danger-hover: #c82333;
   --color-success: #28a745;
-  --color-disabled: #cccccc;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+  --color-overlay: rgba(0, 0, 0, 0.5);
+  --color-input-bg: #ffffff;
+  --color-btn-qty-bg: #f5f5f5;
+  --color-btn-qty-hover: #e0e0e0;
 
-  --badge-available-bg: #d4edda;
-  --badge-available-text: #155724;
-  --badge-offshelf-bg: #f8d7da;
-  --badge-offshelf-text: #721c24;
-  --badge-processing-bg: #fff3cd;
-  --badge-processing-text: #856404;
-  --badge-shipped-bg: #cce5ff;
-  --badge-shipped-text: #004085;
-  --badge-completed-bg: #d4edda;
-  --badge-completed-text: #155724;
-  --badge-canceled-bg: #f8d7da;
-  --badge-canceled-text: #721c24;
+  /* Admin sidebar */
+  --color-sidebar-bg: #2c3e50;
+  --color-sidebar-text: #ffffff;
+  --color-sidebar-active: #3498db;
+  --color-sidebar-hover: rgba(255, 255, 255, 0.1);
 
-  --theme-toggle-bg: #e0e0e0;
-  --theme-toggle-text: #333333;
+  /* State badge colours */
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-off-shelf-bg: #f8d7da;
+  --color-badge-off-shelf-text: #721c24;
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
 }
 
+/* ── Dark theme ── */
 [data-theme="dark"] {
-  --bg-primary: #121212;
-  --bg-secondary: #1e1e1e;
-  --bg-tertiary: #2a2a2a;
-  --bg-hover: #2a2a2a;
-  --bg-input: #2a2a2a;
-  --bg-sidebar: #1a252f;
-  --bg-button-muted: #2a2a2a;
-  --bg-button-muted-hover: #3a3a3a;
-  --bg-quantity-btn: #2a2a2a;
-  --bg-quantity-btn-hover: #3a3a3a;
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-alt: #252525;
+  --color-border: #3a3a3a;
+  --color-border-light: #2c2c2c;
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #a0a0a0;
+  --color-text-muted: #6c6c6c;
+  --color-accent: #4dabf7;
+  --color-accent-hover: #339af0;
+  --color-accent-disabled: #444444;
+  --color-danger: #ff6b6b;
+  --color-danger-hover: #fa5252;
+  --color-success: #51cf66;
+  --color-secondary: #868e96;
+  --color-secondary-hover: #6c757d;
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-shadow-hover: rgba(0, 0, 0, 0.6);
+  --color-overlay: rgba(0, 0, 0, 0.7);
+  --color-input-bg: #2a2a2a;
+  --color-btn-qty-bg: #2e2e2e;
+  --color-btn-qty-hover: #3a3a3a;
 
-  --text-primary: #e0e0e0;
-  --text-secondary: #aaaaaa;
-  --text-muted: #777777;
-  --text-on-dark: #ffffff;
-  --text-on-primary: #ffffff;
+  /* Admin sidebar */
+  --color-sidebar-bg: #1a2332;
+  --color-sidebar-text: #e0e0e0;
+  --color-sidebar-active: #2980b9;
+  --color-sidebar-hover: rgba(255, 255, 255, 0.08);
 
-  --border-color: #3a3a3a;
-  --border-light: #2e2e2e;
-  --border-form: #3a3a3a;
-  --border-focus: #4da3ff;
-
-  --shadow-card: 0 2px 4px rgba(0, 0, 0, 0.4);
-  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.5);
-  --shadow-header: 0 2px 4px rgba(0, 0, 0, 0.4);
-  --shadow-menu: 0 4px 8px rgba(0, 0, 0, 0.4);
-
-  --color-primary: #4da3ff;
-  --color-primary-hover: #1a84ff;
-  --color-secondary: #8a9099;
-  --color-secondary-hover: #6c7580;
-  --color-danger: #e85d6d;
-  --color-danger-hover: #d43f52;
-  --color-success: #48bb6a;
-  --color-disabled: #555555;
-
-  --badge-available-bg: #1a3a2a;
-  --badge-available-text: #5adf8a;
-  --badge-offshelf-bg: #3a1a1e;
-  --badge-offshelf-text: #f08090;
-  --badge-processing-bg: #3a2e00;
-  --badge-processing-text: #ffd966;
-  --badge-shipped-bg: #002244;
-  --badge-shipped-text: #66aaff;
-  --badge-completed-bg: #1a3a2a;
-  --badge-completed-text: #5adf8a;
-  --badge-canceled-bg: #3a1a1e;
-  --badge-canceled-text: #f08090;
-
-  --theme-toggle-bg: #3a3a3a;
-  --theme-toggle-text: #e0e0e0;
+  /* State badge colours */
+  --color-badge-available-bg: #1a3a2a;
+  --color-badge-available-text: #6fcf97;
+  --color-badge-off-shelf-bg: #3a1a1a;
+  --color-badge-off-shelf-text: #ff8a80;
+  --color-badge-processing-bg: #3a2e00;
+  --color-badge-processing-text: #ffd54f;
+  --color-badge-shipped-bg: #003a5c;
+  --color-badge-shipped-text: #81d4fa;
+  --color-badge-completed-bg: #1a3a2a;
+  --color-badge-completed-text: #6fcf97;
+  --color-badge-canceled-bg: #3a1a1a;
+  --color-badge-canceled-text: #ff8a80;
 }
 
 * {
@@ -120,8 +103,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
   transition: background-color 0.2s, color 0.2s;
 }
 
@@ -135,6 +118,10 @@ button {
 input, textarea {
   font-family: inherit;
   outline: none;
+}
+
+select {
+  font-family: inherit;
 }
 
 .container {
@@ -152,22 +139,22 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: var(--color-primary);
-  color: var(--text-on-primary);
+  background-color: var(--color-accent);
+  color: white;
 }
 
 .btn-primary:hover {
-  background-color: var(--color-primary-hover);
+  background-color: var(--color-accent-hover);
 }
 
 .btn-primary:disabled {
-  background-color: var(--color-disabled);
+  background-color: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
   background-color: var(--color-secondary);
-  color: var(--text-on-primary);
+  color: white;
 }
 
 .btn-secondary:hover {
@@ -176,7 +163,7 @@ input, textarea {
 
 .btn-danger {
   background-color: var(--color-danger);
-  color: var(--text-on-primary);
+  color: white;
 }
 
 .btn-danger:hover {
@@ -184,16 +171,16 @@ input, textarea {
 }
 
 .card {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: var(--shadow-card);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-card-hover);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
 .modal-overlay {
@@ -202,7 +189,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -210,7 +197,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: var(--bg-secondary);
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -226,22 +213,22 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid var(--border-form);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
-  background-color: var(--bg-input);
-  color: var(--text-primary);
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
   transition: border-color 0.2s, background-color 0.2s;
 }
 
 .form-input:focus {
-  border-color: var(--border-focus);
+  border-color: var(--color-accent);
 }
 
 .error-message {
@@ -250,21 +237,26 @@ input, textarea {
   margin-top: 4px;
 }
 
-/* Dark mode toggle button */
+/* ── Dark-mode toggle button ── */
 .theme-toggle {
-  background: var(--theme-toggle-bg);
-  color: var(--theme-toggle-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
   border-radius: 20px;
   padding: 6px 12px;
   font-size: 18px;
+  color: var(--color-text-primary);
   display: flex;
   align-items: center;
   gap: 6px;
-  transition: background 0.2s;
+  transition: background 0.2s, border-color 0.2s;
   cursor: pointer;
-  border: none;
 }
 
 .theme-toggle:hover {
-  opacity: 0.85;
+  background: var(--color-surface-alt);
+}
+
+.theme-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
 }

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,113 @@
+/* CSS custom properties for theming */
+:root,
+[data-theme="light"] {
+  --bg-primary: #f5f5f5;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f8f9fa;
+  --bg-hover: #f8f9fa;
+  --bg-input: #ffffff;
+  --bg-sidebar: #2c3e50;
+  --bg-button-muted: #f5f5f5;
+  --bg-button-muted-hover: #e0e0e0;
+  --bg-quantity-btn: #f5f5f5;
+  --bg-quantity-btn-hover: #e0e0e0;
+
+  --text-primary: #333333;
+  --text-secondary: #666666;
+  --text-muted: #999999;
+  --text-on-dark: #ffffff;
+  --text-on-primary: #ffffff;
+
+  --border-color: #dddddd;
+  --border-light: #eeeeee;
+  --border-form: #dddddd;
+  --border-focus: #007bff;
+
+  --shadow-card: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --shadow-header: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-menu: 0 4px 8px rgba(0, 0, 0, 0.1);
+
+  --color-primary: #007bff;
+  --color-primary-hover: #0056b3;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-success: #28a745;
+  --color-disabled: #cccccc;
+
+  --badge-available-bg: #d4edda;
+  --badge-available-text: #155724;
+  --badge-offshelf-bg: #f8d7da;
+  --badge-offshelf-text: #721c24;
+  --badge-processing-bg: #fff3cd;
+  --badge-processing-text: #856404;
+  --badge-shipped-bg: #cce5ff;
+  --badge-shipped-text: #004085;
+  --badge-completed-bg: #d4edda;
+  --badge-completed-text: #155724;
+  --badge-canceled-bg: #f8d7da;
+  --badge-canceled-text: #721c24;
+
+  --theme-toggle-bg: #e0e0e0;
+  --theme-toggle-text: #333333;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #121212;
+  --bg-secondary: #1e1e1e;
+  --bg-tertiary: #2a2a2a;
+  --bg-hover: #2a2a2a;
+  --bg-input: #2a2a2a;
+  --bg-sidebar: #1a252f;
+  --bg-button-muted: #2a2a2a;
+  --bg-button-muted-hover: #3a3a3a;
+  --bg-quantity-btn: #2a2a2a;
+  --bg-quantity-btn-hover: #3a3a3a;
+
+  --text-primary: #e0e0e0;
+  --text-secondary: #aaaaaa;
+  --text-muted: #777777;
+  --text-on-dark: #ffffff;
+  --text-on-primary: #ffffff;
+
+  --border-color: #3a3a3a;
+  --border-light: #2e2e2e;
+  --border-form: #3a3a3a;
+  --border-focus: #4da3ff;
+
+  --shadow-card: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --shadow-card-hover: 0 4px 8px rgba(0, 0, 0, 0.5);
+  --shadow-header: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --shadow-menu: 0 4px 8px rgba(0, 0, 0, 0.4);
+
+  --color-primary: #4da3ff;
+  --color-primary-hover: #1a84ff;
+  --color-secondary: #8a9099;
+  --color-secondary-hover: #6c7580;
+  --color-danger: #e85d6d;
+  --color-danger-hover: #d43f52;
+  --color-success: #48bb6a;
+  --color-disabled: #555555;
+
+  --badge-available-bg: #1a3a2a;
+  --badge-available-text: #5adf8a;
+  --badge-offshelf-bg: #3a1a1e;
+  --badge-offshelf-text: #f08090;
+  --badge-processing-bg: #3a2e00;
+  --badge-processing-text: #ffd966;
+  --badge-shipped-bg: #002244;
+  --badge-shipped-text: #66aaff;
+  --badge-completed-bg: #1a3a2a;
+  --badge-completed-text: #5adf8a;
+  --badge-canceled-bg: #3a1a1e;
+  --badge-canceled-text: #f08090;
+
+  --theme-toggle-bg: #3a3a3a;
+  --theme-toggle-text: #e0e0e0;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +120,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -40,48 +152,48 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-primary);
+  color: var(--text-on-primary);
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
-  color: white;
+  background-color: var(--color-secondary);
+  color: var(--text-on-primary);
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
-  color: white;
+  background-color: var(--color-danger);
+  color: var(--text-on-primary);
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
 .card {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
   padding: 16px;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .modal-overlay {
@@ -98,7 +210,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--bg-secondary);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +226,45 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-form);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
+  transition: border-color 0.2s, background-color 0.2s;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--border-focus);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* Dark mode toggle button */
+.theme-toggle {
+  background: var(--theme-toggle-bg);
+  color: var(--theme-toggle-text);
+  border-radius: 20px;
+  padding: 6px 12px;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.2s;
+  cursor: pointer;
+  border: none;
+}
+
+.theme-toggle:hover {
+  opacity: 0.85;
 }


### PR DESCRIPTION
## Summary

Implements dark mode for the Web UI as requested in [crafting\-demo/demo\-shop\#49](https://github.com/crafting-demo/demo-shop/issues/49).

## Changes

### New File
- **`src/ts/web/src/shared/ThemeContext.tsx`** — React Context for theme state management with `ThemeProvider` and `useTheme` hook

### Updated Files
- **`src/ts/web/src/shared/styles.css`** — Replaced all hardcoded colours with CSS custom properties (variables); defined complete light and dark palettes using `:root`/`[data-theme="light"]` and `[data-theme="dark"]` attribute selectors
- **`src/ts/web/src/customer/index.tsx`** / **`src/ts/web/src/admin/index.tsx`** — Wrapped apps in `ThemeProvider`
- **`src/ts/web/src/admin/AdminApp.tsx`** — Added theme toggle button to sidebar footer
- **`src/ts/web/src/customer/pages/LandingPage.tsx`** — Added theme toggle button (🌙/☀️) to page header
- All `*.css` files — Converted hardcoded colours to CSS variables for full dark mode support

## Features
- 🌙 **Dark mode** with carefully chosen accessible colour palette
- ☀️ **Light mode** preserves the original visual design
- 🔘 **Toggle button** in both customer header and admin sidebar (🌙 Dark / ☀️ Light)
- 💾 **Persisted preference** via `localStorage`
- 🖥️ **System preference detection** — defaults to OS dark/light mode preference (`prefers-color-scheme`)
- ✨ **Smooth transitions** on background and colour changes (0.2s)

## Testing

- ✅ TypeScript type check passed (`npm run type-check`)
- ✅ Production build succeeded (`npm run build`)
- ✅ Built assets verified in `bin/web/` (served by `frontd` daemon)
- ✅ App responding at http://localhost:8080 and http://localhost:8081

**Sandbox**: `ai-7f3a9c2e1b804d5f`  
**Template**: `demo-shop`

Closes #49