### PR TITLE
feat: implement dark mode in Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,15 +5,21 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
-  color: white;
+  background: var(--bg-sidebar);
+  color: var(--text-on-dark);
   padding: 24px;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar h1 {
   font-size: 24px;
+  margin-bottom: 8px;
+  color: var(--text-on-dark);
+}
+
+.sidebar-header {
   margin-bottom: 32px;
-  color: white;
 }
 
 .sidebar nav {
@@ -25,7 +31,7 @@
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: white;
+  color: var(--text-on-dark);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -37,11 +43,29 @@
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--bg-sidebar-active);
+}
+
+.sidebar-theme-toggle {
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.sidebar-theme-toggle .theme-toggle {
+  width: 100%;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-on-dark);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.sidebar-theme-toggle .theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background: var(--bg-primary);
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import { useTheme } from '../shared/ThemeContext';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -36,7 +38,9 @@ const AdminApp: React.FC = () => {
   return (
     <div className="admin-app">
       <div className="sidebar">
-        <h1>Admin Panel</h1>
+        <div className="sidebar-header">
+          <h1>Admin Panel</h1>
+        </div>
         <nav>
           <button
             className={`nav-item ${currentTab === 'inventory' ? 'active' : ''}`}
@@ -57,6 +61,11 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <div className="sidebar-theme-toggle">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+            {theme === 'dark' ? '☀️ Light Mode' : '🌙 Dark Mode'}
+          </button>
+        </div>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,5 +1,5 @@
 .inventory-admin {
-  background: white;
+  background: var(--bg-surface);
   border-radius: 8px;
   padding: 24px;
 }
@@ -13,7 +13,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +24,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +52,19 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--bg-surface-alt);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg-surface);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .col-image img {
@@ -73,17 +76,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .state-badge {
@@ -94,13 +97,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-available-bg);
+  color: var(--badge-available-color);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-off-shelf-bg);
+  color: var(--badge-off-shelf-color);
 }
 
 .col-actions {
@@ -108,26 +111,26 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--bg-surface-alt);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--bg-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +140,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--bg-surface);
+  color: var(--text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
 }
 
 .action-menu button:last-child {
@@ -148,7 +151,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .pagination {
@@ -161,21 +164,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--accent-primary);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--accent-secondary);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--accent-primary-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,11 @@
 .order-admin {
-  background: white;
+  background: var(--bg-surface);
   border-radius: 8px;
   padding: 24px;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +20,62 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--bg-surface-alt);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--bg-surface);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--bg-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--badge-processing-bg);
+  color: var(--badge-processing-color);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--badge-shipped-bg);
+  color: var(--badge-shipped-color);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-completed-bg);
+  color: var(--badge-completed-color);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-canceled-bg);
+  color: var(--badge-canceled-color);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .header-actions {
@@ -29,10 +29,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--border-light);
 }
 
 .form-row {
@@ -60,5 +60,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--border-light);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -1,5 +1,6 @@
 .checkout-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .empty-cart {
@@ -9,7 +10,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +41,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +60,13 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--bg-qty-btn);
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--bg-qty-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +79,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--text-primary);
 }
 
 .item-total {
@@ -88,7 +90,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .cart-summary {
@@ -99,7 +101,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +110,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--border-light);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -1,10 +1,11 @@
 .landing-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -16,12 +17,18 @@
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--accent-primary);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +39,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--accent-primary-hover);
 }
 
 .cart-icon {
@@ -40,7 +47,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--accent-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +81,20 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent-primary);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -18,6 +19,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
   onCartClick,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const { data, loading, fetchMore } = useQuery<GetProductsQuery, GetProductsQueryVariables>(
     GET_PRODUCTS,
@@ -60,12 +62,17 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+            {theme === 'dark' ? '☀️' : '🌙'}
+          </button>
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -1,5 +1,6 @@
 .payment-page {
   min-height: 100vh;
+  background-color: var(--bg-primary);
 }
 
 .payment-form {
@@ -10,24 +11,25 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--accent-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--payment-summary-bg);
   border-radius: 8px;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--text-primary);
 }
 
 .summary-row {
@@ -39,7 +41,7 @@
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--bg-close-btn);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--bg-close-btn-hover);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent-primary);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -3,6 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: var(--bg-primary);
 }
 
 .thankyou-card {
@@ -15,7 +16,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--accent-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +27,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark' || stored === 'light') return stored;
+    // Respect OS preference on first visit
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,108 @@
+/* ── Theme tokens ─────────────────────────────────────────── */
+:root,
+[data-theme="light"] {
+  --bg-primary: #f5f5f5;
+  --bg-surface: #ffffff;
+  --bg-surface-alt: #f8f9fa;
+  --bg-hover: #f0f0f0;
+  --bg-input: #ffffff;
+  --bg-sidebar: #2c3e50;
+  --bg-sidebar-active: #3498db;
+  --bg-modal-overlay: rgba(0, 0, 0, 0.5);
+  --bg-close-btn: #f5f5f5;
+  --bg-close-btn-hover: #e0e0e0;
+  --bg-qty-btn: #f5f5f5;
+  --bg-qty-btn-hover: #e0e0e0;
+
+  --text-primary: #333333;
+  --text-secondary: #666666;
+  --text-muted: #888888;
+  --text-on-dark: #ffffff;
+  --text-label: #333333;
+
+  --border-color: #dddddd;
+  --border-light: #eeeeee;
+
+  --accent-primary: #007bff;
+  --accent-primary-hover: #0056b3;
+  --accent-danger: #dc3545;
+  --accent-danger-hover: #c82333;
+  --accent-secondary: #6c757d;
+  --accent-secondary-hover: #545b62;
+  --accent-success: #28a745;
+
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --shadow-card: 0 4px 8px rgba(0, 0, 0, 0.1);
+
+  --badge-available-bg: #d4edda;
+  --badge-available-color: #155724;
+  --badge-off-shelf-bg: #f8d7da;
+  --badge-off-shelf-color: #721c24;
+  --badge-processing-bg: #fff3cd;
+  --badge-processing-color: #856404;
+  --badge-shipped-bg: #cce5ff;
+  --badge-shipped-color: #004085;
+  --badge-completed-bg: #d4edda;
+  --badge-completed-color: #155724;
+  --badge-canceled-bg: #f8d7da;
+  --badge-canceled-color: #721c24;
+
+  --payment-summary-bg: #f8f9fa;
+}
+
+[data-theme="dark"] {
+  --bg-primary: #121212;
+  --bg-surface: #1e1e1e;
+  --bg-surface-alt: #2a2a2a;
+  --bg-hover: #2e2e2e;
+  --bg-input: #2a2a2a;
+  --bg-sidebar: #1a2332;
+  --bg-sidebar-active: #2980b9;
+  --bg-modal-overlay: rgba(0, 0, 0, 0.75);
+  --bg-close-btn: #3a3a3a;
+  --bg-close-btn-hover: #4a4a4a;
+  --bg-qty-btn: #3a3a3a;
+  --bg-qty-btn-hover: #4a4a4a;
+
+  --text-primary: #e0e0e0;
+  --text-secondary: #aaaaaa;
+  --text-muted: #777777;
+  --text-on-dark: #ffffff;
+  --text-label: #cccccc;
+
+  --border-color: #404040;
+  --border-light: #333333;
+
+  --accent-primary: #4da3ff;
+  --accent-primary-hover: #1a88ff;
+  --accent-danger: #ff6b6b;
+  --accent-danger-hover: #e05555;
+  --accent-secondary: #8a9bb0;
+  --accent-secondary-hover: #6d7f91;
+  --accent-success: #4caf50;
+
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+  --shadow-card: 0 4px 8px rgba(0, 0, 0, 0.4);
+
+  --badge-available-bg: #1a3d26;
+  --badge-available-color: #6fcf97;
+  --badge-off-shelf-bg: #3d1a1a;
+  --badge-off-shelf-color: #f28b82;
+  --badge-processing-bg: #3d2e00;
+  --badge-processing-color: #ffd166;
+  --badge-shipped-bg: #00204d;
+  --badge-shipped-color: #7ec8e3;
+  --badge-completed-bg: #1a3d26;
+  --badge-completed-color: #6fcf97;
+  --badge-canceled-bg: #3d1a1a;
+  --badge-canceled-color: #f28b82;
+
+  --payment-summary-bg: #2a2a2a;
+}
+
+/* ── Reset ────────────────────────────────────────────────── */
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +115,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -25,12 +132,32 @@ input, textarea {
   outline: none;
 }
 
+/* ── Dark mode toggle button ──────────────────────────────── */
+.theme-toggle {
+  background: var(--bg-close-btn);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.2s;
+}
+
+.theme-toggle:hover {
+  background: var(--bg-close-btn-hover);
+}
+
+/* ── Layout helpers ───────────────────────────────────────── */
 .container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
 }
 
+/* ── Buttons ──────────────────────────────────────────────── */
 .btn {
   padding: 12px 24px;
   border-radius: 4px;
@@ -40,57 +167,59 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--accent-primary);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--accent-primary-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--accent-secondary);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--accent-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--accent-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--accent-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--accent-danger-hover);
 }
 
+/* ── Card ─────────────────────────────────────────────────── */
 .card {
-  background: white;
+  background: var(--bg-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   padding: 16px;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
+/* ── Modal ────────────────────────────────────────────────── */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--bg-modal-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +227,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--bg-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -106,6 +235,7 @@ input, textarea {
   padding: 24px;
 }
 
+/* ── Form ─────────────────────────────────────────────────── */
 .form-group {
   margin-bottom: 16px;
 }
@@ -114,23 +244,25 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--text-label);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--accent-primary);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--accent-danger);
   font-size: 14px;
   margin-top: 4px;
 }


### PR DESCRIPTION
## Summary

Implements dark mode across the entire Web UI for both the customer-facing shop and the admin panel.

Closes #52
[crafting\-demo/demo\-shop\#52](https://github.com/crafting-demo/demo-shop/issues/52)

## Changes

### New: `ThemeContext.tsx`
- React context + `ThemeProvider` component that manages the active theme (`light` | `dark`)
- Persists the user's preference in `localStorage`
- Automatically initialises from the OS `prefers-color-scheme` media query on first visit
- Exports `useTheme()` hook for easy access anywhere in the tree

### Updated: `shared/styles.css`
- Converted all hard-coded colours to CSS custom properties (design tokens)
- Full token set defined for both `:root / [data-theme="light"]` and `[data-theme="dark"]`
- Covers: backgrounds, surfaces, text, borders, accents, badges, shadows, and overlays
- Added `.theme-toggle` base style used by both apps
- `body` now picks up `--bg-primary` and `--text-primary`, with a smooth 0.2 s transition

### Customer app
- `index.tsx`: wrapped in `<ThemeProvider>`
- `LandingPage.tsx`: added 🌙 / ☀️ toggle button in the header
- All CSS files updated to use CSS variables

### Admin app
- `index.tsx`: wrapped in `<ThemeProvider>`
- `AdminApp.tsx`: added 🌙 Dark Mode / ☀️ Light Mode toggle at the bottom of the sidebar
- All CSS files updated to use CSS variables

## Testing

- `tsc --noEmit` → ✅ no type errors
- `npm run build` → ✅ successful production build (all 8 chunks emitted)
- Live apps verified in sandbox:
  - Customer: https://app--ai-7f3b2e9d1c4a8f05-demo.crafting.site.sandboxes.run
  - Admin: https://admin--ai-7f3b2e9d1c4a8f05-demo.crafting.site.sandboxes.run

## Sandbox / Template

- **Sandbox**: `ai-7f3b2e9d1c4a8f05`
- **Template**: `demo-shop`