### PR TITLE
feat: implement dark mode in Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -8,6 +8,15 @@
   background: #2c3e50;
   color: white;
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  transition: background-color 0.2s;
+}
+
+[data-theme="dark"] .sidebar {
+  background: #1a252f;
+  border-right: 1px solid #2e2e2e;
 }
 
 .sidebar h1 {
@@ -20,6 +29,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
 }
 
 .nav-item {
@@ -40,8 +50,30 @@
   background: #3498db;
 }
 
+.sidebar-toggle {
+  margin-top: 16px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  justify-content: flex-start;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  transition: background 0.2s;
+}
+
+.sidebar-toggle:hover {
+  background: rgba(255, 255, 255, 0.2) !important;
+}
+
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background-color: var(--color-bg);
+  transition: background-color 0.2s;
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import { useDarkMode } from '../shared/useDarkMode';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useDarkMode();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -57,6 +59,10 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <button className="dark-mode-toggle sidebar-toggle" onClick={toggleTheme} title="Toggle dark mode">
+          {theme === 'dark' ? '☀️' : '🌙'}
+          <span>{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</span>
+        </button>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +25,21 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, border-color 0.2s;
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +54,21 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-secondary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .col-image img {
@@ -73,17 +80,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .state-badge {
@@ -94,13 +101,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-offshelf-bg);
+  color: var(--color-badge-offshelf-text);
 }
 
 .col-actions {
@@ -108,28 +115,30 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-action-btn-bg);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-action-btn-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
+  transition: background-color 0.2s;
 }
 
 .action-menu button {
@@ -137,10 +146,11 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  transition: background-color 0.2s;
 }
 
 .action-menu button:last-child {
@@ -148,7 +158,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .pagination {
@@ -161,21 +171,22 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   border-radius: 4px;
+  transition: background-color 0.2s;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-primary-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +21,64 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-secondary);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -20,7 +20,11 @@
 }
 
 .edit-form {
+  background: var(--color-surface);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 32px;
+  transition: background-color 0.2s;
 }
 
 .form-section {
@@ -29,10 +33,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-light);
 }
 
 .form-row {
@@ -60,5 +64,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-light);
 }

--- a/src/ts/web/src/customer/CustomerApp.tsx
+++ b/src/ts/web/src/customer/CustomerApp.tsx
@@ -8,12 +8,14 @@ import PaymentPage from './pages/PaymentPage';
 import ThankYouPage from './pages/ThankYouPage';
 import { GET_CART } from './queries';
 import { GetCartQuery } from '../generated/graphql';
+import { useDarkMode } from '../shared/useDarkMode';
 
 type Page = 'landing' | 'product' | 'checkout' | 'payment' | 'thankyou';
 
 const CustomerApp: React.FC = () => {
   const [currentPage, setCurrentPage] = useState<Page>('landing');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useDarkMode();
 
   const { data: cartData, refetch: refetchCart } = useQuery<GetCartQuery>(GET_CART);
 
@@ -56,6 +58,12 @@ const CustomerApp: React.FC = () => {
     await refetchCart();
   };
 
+  const darkModeToggle = (
+    <button className="dark-mode-toggle" onClick={toggleTheme} title="Toggle dark mode">
+      {theme === 'dark' ? '☀️' : '🌙'}
+    </button>
+  );
+
   return (
     <div>
       {currentPage === 'landing' && (
@@ -63,6 +71,7 @@ const CustomerApp: React.FC = () => {
           cartItemCount={cartItemCount}
           onProductClick={handleProductClick}
           onCartClick={handleGoToCheckout}
+          darkModeToggle={darkModeToggle}
         />
       )}
       {currentPage === 'product' && selectedProduct && (
@@ -78,6 +87,7 @@ const CustomerApp: React.FC = () => {
           onUpdateQuantity={handleUpdateQuantity}
           onCheckout={handleGoToPayment}
           onBack={handleBackToLanding}
+          darkModeToggle={darkModeToggle}
         />
       )}
       {currentPage === 'payment' && cart && (
@@ -85,10 +95,14 @@ const CustomerApp: React.FC = () => {
           totalPrice={cart.totalPrice}
           onPlaceOrder={handlePlaceOrder}
           onBack={() => setCurrentPage('checkout')}
+          darkModeToggle={darkModeToggle}
         />
       )}
       {currentPage === 'thankyou' && (
-        <ThankYouPage onContinueShopping={handleBackToLanding} />
+        <ThankYouPage
+          onContinueShopping={handleBackToLanding}
+          darkModeToggle={darkModeToggle}
+        />
       )}
     </div>
   );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -2,6 +2,29 @@
   min-height: 100vh;
 }
 
+.header {
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: background-color 0.2s;
+}
+
+.header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
 .empty-cart {
   text-align: center;
   padding: 60px 20px;
@@ -9,7 +32,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +63,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +82,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-qty-btn-bg);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-qty-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +102,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +113,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .cart-summary {
@@ -99,7 +124,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +133,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.tsx
+++ b/src/ts/web/src/customer/pages/CheckoutPage.tsx
@@ -16,6 +16,7 @@ interface CheckoutPageProps {
   onUpdateQuantity: () => void;
   onCheckout: () => void;
   onBack: () => void;
+  darkModeToggle?: React.ReactNode;
 }
 
 const CheckoutPage: React.FC<CheckoutPageProps> = ({
@@ -23,6 +24,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
   onUpdateQuantity,
   onCheckout,
   onBack,
+  darkModeToggle,
 }) => {
   const [updateCartItem] = useMutation<UpdateCartItemMutation, UpdateCartItemMutationVariables>(
     UPDATE_CART_ITEM
@@ -55,7 +57,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
           ← Back
         </button>
         <h1>Shopping Cart</h1>
-        <div></div>
+        <div className="header-right">{darkModeToggle}</div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,23 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.2s;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -29,10 +36,11 @@
   align-items: center;
   gap: 8px;
   font-size: 18px;
+  transition: background-color 0.2s;
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .cart-icon {
@@ -40,7 +48,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +82,27 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-secondary);
+  font-size: 18px;
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -10,12 +10,14 @@ interface LandingPageProps {
   cartItemCount: number;
   onProductClick: (product: Product) => void;
   onCartClick: () => void;
+  darkModeToggle?: React.ReactNode;
 }
 
 const LandingPage: React.FC<LandingPageProps> = ({
   cartItemCount,
   onProductClick,
   onCartClick,
+  darkModeToggle,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
 
@@ -60,12 +62,15 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          {darkModeToggle}
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -2,6 +2,29 @@
   min-height: 100vh;
 }
 
+.header {
+  background: var(--color-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: background-color 0.2s;
+}
+
+.header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
 .payment-form {
   max-width: 600px;
   margin: 0 auto;
@@ -10,36 +33,39 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-surface-secondary);
   border-radius: 8px;
+  transition: background-color 0.2s;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--color-text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.tsx
+++ b/src/ts/web/src/customer/pages/PaymentPage.tsx
@@ -8,6 +8,7 @@ interface PaymentPageProps {
   totalPrice: number; // in cents
   onPlaceOrder: () => void;
   onBack: () => void;
+  darkModeToggle?: React.ReactNode;
 }
 
 interface CustomerInfo {
@@ -20,6 +21,7 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
   totalPrice,
   onPlaceOrder,
   onBack,
+  darkModeToggle,
 }) => {
   const [customerInfo, setCustomerInfo] = useState<CustomerInfo>({
     name: '',
@@ -89,7 +91,7 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
           ← Back
         </button>
         <h1>Payment</h1>
-        <div></div>
+        <div className="header-right">{darkModeToggle}</div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-close-btn-bg);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,13 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
+  transition: background-color 0.2s;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-close-btn-hover);
 }
 
 .product-detail {
@@ -51,12 +52,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +70,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -3,6 +3,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+}
+
+.thankyou-toggle {
+  position: absolute;
+  top: 16px;
+  right: 20px;
 }
 
 .thankyou-card {
@@ -15,7 +22,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +33,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/customer/pages/ThankYouPage.tsx
+++ b/src/ts/web/src/customer/pages/ThankYouPage.tsx
@@ -3,11 +3,15 @@ import './ThankYouPage.css';
 
 interface ThankYouPageProps {
   onContinueShopping: () => void;
+  darkModeToggle?: React.ReactNode;
 }
 
-const ThankYouPage: React.FC<ThankYouPageProps> = ({ onContinueShopping }) => {
+const ThankYouPage: React.FC<ThankYouPageProps> = ({ onContinueShopping, darkModeToggle }) => {
   return (
     <div className="thankyou-page">
+      {darkModeToggle && (
+        <div className="thankyou-toggle">{darkModeToggle}</div>
+      )}
       <div className="container">
         <div className="thankyou-card card">
           <div className="success-icon">✓</div>

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,131 @@
+:root {
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f8f9fa;
+  --color-surface-secondary: #f8f9fa;
+  --color-border: #dddddd;
+  --color-border-light: #eeeeee;
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+  --color-primary: #007bff;
+  --color-primary-hover: #0056b3;
+  --color-primary-disabled: #cccccc;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-success: #28a745;
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+  --color-overlay: rgba(0, 0, 0, 0.5);
+  --color-input-bg: #ffffff;
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-offshelf-bg: #f8d7da;
+  --color-badge-offshelf-text: #721c24;
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
+  --color-qty-btn-bg: #f5f5f5;
+  --color-qty-btn-hover: #e0e0e0;
+  --color-close-btn-bg: #f5f5f5;
+  --color-close-btn-hover: #e0e0e0;
+  --color-action-btn-bg: #f5f5f5;
+  --color-action-btn-hover: #e0e0e0;
+}
+
+[data-theme="dark"] {
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-hover: #2a2a2a;
+  --color-surface-secondary: #252525;
+  --color-border: #3a3a3a;
+  --color-border-light: #2e2e2e;
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #a0a0a0;
+  --color-text-muted: #707070;
+  --color-primary: #4da3ff;
+  --color-primary-hover: #2080e0;
+  --color-primary-disabled: #444444;
+  --color-secondary: #8a9199;
+  --color-secondary-hover: #6c757d;
+  --color-danger: #f06878;
+  --color-danger-hover: #d94f60;
+  --color-success: #4caf70;
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-shadow-hover: rgba(0, 0, 0, 0.5);
+  --color-overlay: rgba(0, 0, 0, 0.7);
+  --color-input-bg: #2c2c2c;
+  --color-badge-available-bg: #1a3a26;
+  --color-badge-available-text: #6fcf97;
+  --color-badge-offshelf-bg: #3a1a1e;
+  --color-badge-offshelf-text: #f06878;
+  --color-badge-processing-bg: #3a3010;
+  --color-badge-processing-text: #f0c040;
+  --color-badge-shipped-bg: #102040;
+  --color-badge-shipped-text: #70b8ff;
+  --color-badge-completed-bg: #1a3a26;
+  --color-badge-completed-text: #6fcf97;
+  --color-badge-canceled-bg: #3a1a1e;
+  --color-badge-canceled-text: #f06878;
+  --color-qty-btn-bg: #2c2c2c;
+  --color-qty-btn-hover: #3a3a3a;
+  --color-close-btn-bg: #2c2c2c;
+  --color-close-btn-hover: #3a3a3a;
+  --color-action-btn-bg: #2c2c2c;
+  --color-action-btn-hover: #3a3a3a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --color-bg: #121212;
+    --color-surface: #1e1e1e;
+    --color-surface-hover: #2a2a2a;
+    --color-surface-secondary: #252525;
+    --color-border: #3a3a3a;
+    --color-border-light: #2e2e2e;
+    --color-text-primary: #e0e0e0;
+    --color-text-secondary: #a0a0a0;
+    --color-text-muted: #707070;
+    --color-primary: #4da3ff;
+    --color-primary-hover: #2080e0;
+    --color-primary-disabled: #444444;
+    --color-secondary: #8a9199;
+    --color-secondary-hover: #6c757d;
+    --color-danger: #f06878;
+    --color-danger-hover: #d94f60;
+    --color-success: #4caf70;
+    --color-shadow: rgba(0, 0, 0, 0.4);
+    --color-shadow-hover: rgba(0, 0, 0, 0.5);
+    --color-overlay: rgba(0, 0, 0, 0.7);
+    --color-input-bg: #2c2c2c;
+    --color-badge-available-bg: #1a3a26;
+    --color-badge-available-text: #6fcf97;
+    --color-badge-offshelf-bg: #3a1a1e;
+    --color-badge-offshelf-text: #f06878;
+    --color-badge-processing-bg: #3a3010;
+    --color-badge-processing-text: #f0c040;
+    --color-badge-shipped-bg: #102040;
+    --color-badge-shipped-text: #70b8ff;
+    --color-badge-completed-bg: #1a3a26;
+    --color-badge-completed-text: #6fcf97;
+    --color-badge-canceled-bg: #3a1a1e;
+    --color-badge-canceled-text: #f06878;
+    --color-qty-btn-bg: #2c2c2c;
+    --color-qty-btn-hover: #3a3a3a;
+    --color-close-btn-bg: #2c2c2c;
+    --color-close-btn-hover: #3a3a3a;
+    --color-action-btn-bg: #2c2c2c;
+    --color-action-btn-hover: #3a3a3a;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +138,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -40,48 +170,48 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-primary-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
 .card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
 .modal-overlay {
@@ -90,7 +220,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +228,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +244,45 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-input-bg);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s, background-color 0.2s;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-primary);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* Dark mode toggle button */
+.dark-mode-toggle {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 6px 12px;
+  font-size: 16px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dark-mode-toggle:hover {
+  background-color: var(--color-surface-secondary);
 }

--- a/src/ts/web/src/shared/useDarkMode.ts
+++ b/src/ts/web/src/shared/useDarkMode.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark';
+
+function getSystemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme | null {
+  try {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function useDarkMode() {
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? getSystemTheme());
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem('theme', theme);
+    } catch {
+      // ignore
+    }
+  }, [theme]);
+
+  // Sync with system preference changes (when no manual override)
+  useEffect(() => {
+    const stored = getStoredTheme();
+    if (stored) return; // user has manual override, skip
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light');
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return { theme, toggleTheme };
+}


### PR DESCRIPTION
## Summary

Implements dark mode for both the Customer and Admin web UIs.

Closes #54
Ref: [crafting-demo/demo-shop#54](https://github.com/crafting-demo/demo-shop/issues/54)

## Changes

### New file
- **`src/ts/web/src/shared/useDarkMode.ts`** — Custom React hook that:
  - Detects the OS/system color-scheme preference (`prefers-color-scheme`)
  - Persists the user's manual selection in `localStorage`
  - Syncs with system preference changes when no manual override is set
  - Exposes `{ theme, toggleTheme }` to consumers

### Updated files
- **`src/ts/web/src/shared/styles.css`** — Defines a full set of CSS custom properties for every color in both `:root` (light) and `[data-theme="dark"]` scopes; also applies dark theme automatically via `@media (prefers-color-scheme: dark)` when no explicit `data-theme="light"` attribute is present. Added `.dark-mode-toggle` button styles.
- **`src/ts/web/src/customer/CustomerApp.tsx`** — Integrates `useDarkMode`; renders a 🌙/☀️ toggle button passed down to all customer pages.
- **`src/ts/web/src/customer/pages/LandingPage.tsx`** — Accepts `darkModeToggle` prop; renders it in the header next to the cart button.
- **`src/ts/web/src/customer/pages/CheckoutPage.tsx`** — Accepts `darkModeToggle` prop; renders it in the page header.
- **`src/ts/web/src/customer/pages/PaymentPage.tsx`** — Accepts `darkModeToggle` prop; renders it in the page header.
- **`src/ts/web/src/customer/pages/ThankYouPage.tsx`** — Accepts `darkModeToggle` prop; renders it as a floating button in the top-right corner.
- All **CSS files** (customer + admin pages) — Replaced all hard-coded color values with CSS variable references; added 0.2s transitions for smooth mode switching.
- **`src/ts/web/src/admin/AdminApp.tsx`** — Integrates `useDarkMode`; renders a labeled 🌙/☀️ toggle button in the sidebar.
- **`src/ts/web/src/admin/AdminApp.css`** — Added `flex-direction: column` to sidebar for proper toggle placement; added dark-mode-specific sidebar color overrides.

## Test Results

- ✅ TypeScript type check passes (`npm run type-check`)
- ✅ Production build succeeds (`npm run build`)
- ✅ API test suite: 146 passed, 13 skipped, 2 pre-existing failures (unrelated to this change — product count edge cases)

## Sandbox & Template

- **Sandbox**: `ai-b3f2e1a9c7d04e5f`
- **Template**: `demo-shop`