### PR TITLE
feat: implement dark mode for Customer and Admin Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,15 +5,18 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
-  color: white;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .sidebar h1 {
   font-size: 24px;
   margin-bottom: 32px;
-  color: white;
+  color: var(--color-text-primary);
 }
 
 .sidebar nav {
@@ -25,7 +28,7 @@
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: white;
+  color: var(--color-text-primary);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -33,15 +36,21 @@
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--color-surface-alt);
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.sidebar-footer {
+  margin-top: auto;
 }
 
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background: var(--color-bg);
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import { useTheme } from '../shared/theme';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -57,6 +59,11 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+        <div className="sidebar-footer">
+          <button className="theme-toggle nav-item" onClick={toggleTheme}>
+            {theme === 'light' ? '🌙 Dark mode' : '☀️ Light mode'}
+          </button>
+        </div>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/theme';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,5 +1,5 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
 }
@@ -13,7 +13,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,18 +24,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +52,18 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
 }
 
 .col-image img {
@@ -73,17 +75,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .state-badge {
@@ -94,13 +96,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-success-soft);
+  color: var(--color-success-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-danger-soft);
+  color: var(--color-danger-text);
 }
 
 .col-actions {
@@ -108,26 +110,26 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-border);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +139,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-surface);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .action-menu button:last-child {
@@ -148,7 +150,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
 }
 
 .pagination {
@@ -161,21 +163,21 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,11 @@
 .order-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,60 +20,61 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-warning-soft);
+  color: var(--color-warning-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-primary-soft);
+  color: var(--color-primary-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-success-soft);
+  color: var(--color-success-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-danger-soft);
+  color: var(--color-danger-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -21,6 +21,8 @@
 
 .edit-form {
   padding: 32px;
+  background: var(--color-surface);
+  border-radius: 8px;
 }
 
 .form-section {
@@ -29,10 +31,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border);
 }
 
 .form-row {
@@ -56,9 +58,10 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  color: var(--color-text-primary);
 }
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/theme';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,13 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-border);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +78,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +89,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .cart-summary {
@@ -99,7 +100,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +109,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -16,12 +16,18 @@
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +38,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .cart-icon {
@@ -40,7 +46,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +80,27 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-secondary);
+  font-size: 18px;
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/theme';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -18,6 +19,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
   onCartClick,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const { data, loading, fetchMore } = useQuery<GetProductsQuery, GetProductsQueryVariables>(
     GET_PRODUCTS,
@@ -60,12 +62,17 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+            {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+          </button>
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,36 +10,38 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-surface-alt);
   border-radius: 8px;
 }
 
 .payment-summary h2 {
   font-size: 20px;
   margin-bottom: 16px;
+  color: var(--color-text-primary);
 }
 
 .summary-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-border);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,89 @@
+/* =====================================================================
+   CSS Custom Properties – light (default) & dark themes
+   Applied to <html> via data-theme attribute by ThemeProvider
+   ===================================================================== */
+:root,
+[data-theme="light"] {
+  --color-bg:           #f5f5f5;
+  --color-surface:      #ffffff;
+  --color-surface-alt:  #f8f9fa;
+  --color-border:       #dddddd;
+  --color-border-light: #eeeeee;
+
+  --color-text-primary:   #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted:     #999999;
+
+  --color-primary:        #007bff;
+  --color-primary-hover:  #0056b3;
+  --color-primary-soft:   #cce5ff;
+  --color-primary-text:   #004085;
+
+  --color-secondary:      #6c757d;
+  --color-secondary-hover:#545b62;
+
+  --color-danger:         #dc3545;
+  --color-danger-hover:   #c82333;
+  --color-danger-soft:    #f8d7da;
+  --color-danger-text:    #721c24;
+
+  --color-success:        #28a745;
+  --color-success-soft:   #d4edda;
+  --color-success-text:   #155724;
+
+  --color-warning-soft:   #fff3cd;
+  --color-warning-text:   #856404;
+
+  --color-disabled:       #cccccc;
+
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --shadow-overlay: rgba(0, 0, 0, 0.5);
+  --shadow-card: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] {
+  --color-bg:           #121212;
+  --color-surface:      #1e1e1e;
+  --color-surface-alt:  #2a2a2a;
+  --color-border:       #3a3a3a;
+  --color-border-light: #2e2e2e;
+
+  --color-text-primary:   #e0e0e0;
+  --color-text-secondary: #a0a0a0;
+  --color-text-muted:     #6e6e6e;
+
+  --color-primary:        #4dabf7;
+  --color-primary-hover:  #339af0;
+  --color-primary-soft:   #1c3a5e;
+  --color-primary-text:   #90cff8;
+
+  --color-secondary:      #868e96;
+  --color-secondary-hover:#6c757d;
+
+  --color-danger:         #f06070;
+  --color-danger-hover:   #e84c5e;
+  --color-danger-soft:    #3d1a1e;
+  --color-danger-text:    #f4a0a8;
+
+  --color-success:        #51cf66;
+  --color-success-soft:   #1a3d22;
+  --color-success-text:   #8ee8a0;
+
+  --color-warning-soft:   #3d3010;
+  --color-warning-text:   #ffe066;
+
+  --color-disabled:       #4a4a4a;
+
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.5);
+  --shadow-overlay: rgba(0, 0, 0, 0.75);
+  --shadow-card: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+/* =====================================================================
+   Global resets & base styles
+   ===================================================================== */
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +96,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -20,9 +108,12 @@ button {
   font-family: inherit;
 }
 
-input, textarea {
+input, textarea, select {
   font-family: inherit;
   outline: none;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
 }
 
 .container {
@@ -31,6 +122,9 @@ input, textarea {
   padding: 20px;
 }
 
+/* =====================================================================
+   Shared button styles
+   ===================================================================== */
 .btn {
   padding: 12px 24px;
   border-radius: 4px;
@@ -40,57 +134,63 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-primary);
+  color: #ffffff;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
-  color: white;
+  background-color: var(--color-secondary);
+  color: #ffffff;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
-  color: white;
+  background-color: var(--color-danger);
+  color: #ffffff;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
+/* =====================================================================
+   Card
+   ===================================================================== */
 .card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   padding: 16px;
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-card);
 }
 
+/* =====================================================================
+   Modal
+   ===================================================================== */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--shadow-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +198,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -106,6 +206,9 @@ input, textarea {
   padding: 24px;
 }
 
+/* =====================================================================
+   Form
+   ===================================================================== */
 .form-group {
   margin-bottom: 16px;
 }
@@ -114,23 +217,46 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-primary);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* =====================================================================
+   Theme toggle button
+   ===================================================================== */
+.theme-toggle {
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 20px;
+  padding: 6px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.theme-toggle:hover {
+  opacity: 1;
 }

--- a/src/ts/web/src/shared/theme.tsx
+++ b/src/ts/web/src/shared/theme.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+const STORAGE_KEY = 'demo-shop-theme';
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    // Respect OS preference if no stored preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Dark Mode Implementation

Closes #58

Resolves: [crafting\-demo/demo\-shop\#58](https://github.com/crafting-demo/demo-shop/issues/58)

### Summary

Implements full dark mode support for both the Customer and Admin Web UIs.

### Changes

#### New: `src/ts/web/src/shared/theme.tsx`
- `ThemeProvider` React context providing theme state and toggle function
- Automatically detects OS `prefers-color-scheme` preference on first load
- Persists the user's choice in `localStorage` across sessions
- Sets `data-theme` attribute on `<html>` element to drive CSS variables

#### Updated: `src/ts/web/src/shared/styles.css`
- Replaced all hardcoded color values with CSS custom properties
- Defined complete light palette under `:root` / `[data-theme="light"]`
- Defined complete dark palette under `[data-theme="dark"]`
- Added `.theme-toggle` button base style
- Added smooth `transition` on `body` background and color

#### Updated: All component CSS files
Converted all hardcoded colours to CSS variables in:
- `customer/pages/LandingPage.css`
- `customer/pages/ProductPage.css`
- `customer/pages/CheckoutPage.css`
- `customer/pages/PaymentPage.css`
- `customer/pages/ThankYouPage.css`
- `admin/AdminApp.css`
- `admin/pages/InventoryAdmin.css`
- `admin/pages/OrderAdmin.css`
- `admin/pages/ProductEdit.css`

#### Updated: Entry points & App components
- Both `customer/index.tsx` and `admin/index.tsx` now wrap the app in `<ThemeProvider>`
- `LandingPage.tsx`: added 🌙/☀️ toggle button in the header actions area
- `AdminApp.tsx`: added 🌙/☀️ toggle button in the sidebar footer

### Test Results

- TypeScript compilation: ✅ No errors (`tsc --noEmit`)
- Vite production build: ✅ Built successfully
- Manual verification: both CSS variable palettes confirmed present in built output

### Sandbox Info
- **Sandbox**: `ai-3f7c2b9e1d4a8f05`
- **Template**: `demo-shop`