### PR TITLE
feat: implement dark mode with CSS custom properties and theme toggle

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,9 +5,12 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
+  background: var(--color-bg-sidebar);
   color: white;
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  transition: background-color 0.2s;
 }
 
 .sidebar h1 {
@@ -20,6 +23,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
 }
 
 .nav-item {
@@ -40,8 +44,17 @@
   background: #3498db;
 }
 
+.sidebar-theme-toggle {
+  margin-top: 24px;
+  border-color: rgba(255, 255, 255, 0.4);
+  width: 100%;
+  justify-content: center;
+}
+
 .main-content {
   flex: 1;
   padding: 24px;
   overflow: auto;
+  background: var(--color-bg-page);
+  transition: background-color 0.2s;
 }

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -3,6 +3,7 @@ import { Product } from '../shared/types';
 import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
+import { useTheme } from '../shared/ThemeContext';
 import './AdminApp.css';
 
 type Tab = 'inventory' | 'orders';
@@ -12,6 +13,7 @@ const AdminApp: React.FC = () => {
   const [currentTab, setCurrentTab] = useState<Tab>('inventory');
   const [currentView, setCurrentView] = useState<View>('list');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const handleEditProduct = (product: Product) => {
     setSelectedProduct(product);
@@ -57,6 +59,11 @@ const AdminApp: React.FC = () => {
             Orders
           </button>
         </nav>
+
+        <button className="theme-toggle sidebar-theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+          <span>{theme === 'dark' ? '☀️' : '🌙'}</span>
+          <span className="theme-toggle-label">{theme === 'dark' ? 'Light Mode' : 'Dark Mode'}</span>
+        </button>
       </div>
 
       <div className="main-content">

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <AdminApp />
+      <ThemeProvider>
+        <AdminApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .page-size-selector {
@@ -24,20 +25,24 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-bg-input);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, border-color 0.2s;
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
+  transition: border-color 0.2s;
 }
 
 .table-header,
@@ -50,18 +55,27 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-table-header);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-table);
+  transition: background-color 0.2s;
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-hover);
+}
+
+.loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-secondary);
+  font-size: 18px;
 }
 
 .col-image img {
@@ -73,17 +87,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .state-badge {
@@ -94,13 +108,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-available-bg);
+  color: var(--color-badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-off-shelf-bg);
+  color: var(--color-badge-off-shelf-text);
 }
 
 .col-actions {
@@ -108,28 +122,30 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-bg-quantity-btn);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
+  transition: background-color 0.2s;
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-bg-quantity-btn-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-bg-action-menu);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px var(--color-shadow);
   z-index: 10;
   min-width: 150px;
+  transition: background-color 0.2s;
 }
 
 .action-menu button {
@@ -137,10 +153,11 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-bg-action-menu-btn);
+  color: var(--color-text-primary);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-table);
+  transition: background-color 0.2s;
 }
 
 .action-menu button:last-child {
@@ -148,7 +165,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-action-menu-btn-hover);
 }
 
 .pagination {
@@ -161,21 +178,22 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   border-radius: 4px;
+  transition: background-color 0.2s;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,13 +1,15 @@
 .order-admin {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background-color 0.2s;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
+  transition: border-color 0.2s;
 }
 
 .order-table .table-header,
@@ -20,60 +22,63 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-bg-table-header);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text-primary);
+  border-bottom: 2px solid var(--color-border);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-table);
+  transition: background-color 0.2s;
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-bg-hover);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .col-customer {
   font-weight: 500;
+  color: var(--color-text-primary);
 }
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-badge-processing-bg);
+  color: var(--color-badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--color-badge-shipped-bg);
+  color: var(--color-badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-badge-completed-bg);
+  color: var(--color-badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-badge-canceled-bg);
+  color: var(--color-badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .header-actions {
@@ -29,10 +29,11 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-section);
+  transition: border-color 0.2s;
 }
 
 .form-row {
@@ -60,5 +61,6 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-section);
+  transition: border-color 0.2s;
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -12,7 +13,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <ApolloProvider client={apolloClient}>
-      <CustomerApp />
+      <ThemeProvider>
+        <CustomerApp />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -2,6 +2,24 @@
   min-height: 100vh;
 }
 
+.header {
+  background: var(--color-bg-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
 .empty-cart {
   text-align: center;
   padding: 60px 20px;
@@ -9,7 +27,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +58,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +77,14 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-bg-quantity-btn);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
+  transition: background-color 0.2s;
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-bg-quantity-btn-hover);
 }
 
 .quantity-controls button:disabled {
@@ -78,6 +97,7 @@
   font-weight: 500;
   min-width: 30px;
   text-align: center;
+  color: var(--color-text-primary);
 }
 
 .item-total {
@@ -88,7 +108,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .cart-summary {
@@ -99,7 +119,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
@@ -108,13 +128,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-section);
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.tsx
+++ b/src/ts/web/src/customer/pages/CheckoutPage.tsx
@@ -9,6 +9,7 @@ import {
   RemoveFromCartMutationVariables,
 } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './CheckoutPage.css';
 
 interface CheckoutPageProps {
@@ -24,6 +25,8 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
   onCheckout,
   onBack,
 }) => {
+  const { theme, toggleTheme } = useTheme();
+
   const [updateCartItem] = useMutation<UpdateCartItemMutation, UpdateCartItemMutationVariables>(
     UPDATE_CART_ITEM
   );
@@ -55,7 +58,10 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
           ← Back
         </button>
         <h1>Shopping Cart</h1>
-        <div></div>
+        <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+          <span>{theme === 'dark' ? '☀️' : '🌙'}</span>
+          <span className="theme-toggle-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+        </button>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-bg-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,23 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background-color 0.2s, box-shadow 0.2s;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-accent);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +39,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-accent-hover);
 }
 
 .cart-icon {
@@ -40,7 +47,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +81,27 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
+}
+
+.loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-secondary);
+  font-size: 18px;
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import { useTheme } from '../../shared/ThemeContext';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -18,6 +19,7 @@ const LandingPage: React.FC<LandingPageProps> = ({
   onCartClick,
 }) => {
   const observerTarget = useRef<HTMLDivElement>(null);
+  const { theme, toggleTheme } = useTheme();
 
   const { data, loading, fetchMore } = useQuery<GetProductsQuery, GetProductsQueryVariables>(
     GET_PRODUCTS,
@@ -60,12 +62,18 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div className="header-actions">
+          <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+            <span>{theme === 'dark' ? '☀️' : '🌙'}</span>
+            <span className="theme-toggle-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+          </button>
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -2,6 +2,24 @@
   min-height: 100vh;
 }
 
+.header {
+  background: var(--color-bg-surface);
+  box-shadow: 0 2px 4px var(--color-shadow);
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.header h1 {
+  font-size: 24px;
+  color: var(--color-text-primary);
+}
+
 .payment-form {
   max-width: 600px;
   margin: 0 auto;
@@ -10,19 +28,20 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-bg-payment-summary);
   border-radius: 8px;
+  transition: background-color 0.2s;
 }
 
 .payment-summary h2 {
@@ -34,12 +53,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: var(--color-text-primary);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.tsx
+++ b/src/ts/web/src/customer/pages/PaymentPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { PLACE_ORDER } from '../queries';
 import { PlaceOrderMutation, PlaceOrderMutationVariables } from '../../generated/graphql';
+import { useTheme } from '../../shared/ThemeContext';
 import './PaymentPage.css';
 
 interface PaymentPageProps {
@@ -21,6 +22,7 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
   onPlaceOrder,
   onBack,
 }) => {
+  const { theme, toggleTheme } = useTheme();
   const [customerInfo, setCustomerInfo] = useState<CustomerInfo>({
     name: '',
     email: '',
@@ -89,7 +91,10 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
           ← Back
         </button>
         <h1>Payment</h1>
-        <div></div>
+        <button className="theme-toggle" onClick={toggleTheme} title="Toggle dark mode">
+          <span>{theme === 'dark' ? '☀️' : '🌙'}</span>
+          <span className="theme-toggle-label">{theme === 'dark' ? 'Light' : 'Dark'}</span>
+        </button>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-bg-close-btn);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,13 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
+  transition: background-color 0.2s;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-bg-close-btn-hover);
 }
 
 .product-detail {
@@ -51,12 +52,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +70,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-accent);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    // Persist preference across sessions, with system default as fallback
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,112 @@
+/* ====== CSS Custom Properties (Design Tokens) ====== */
+:root,
+[data-theme="light"] {
+  --color-bg-page: #f5f5f5;
+  --color-bg-surface: #ffffff;
+  --color-bg-muted: #f8f9fa;
+  --color-bg-input: #ffffff;
+  --color-bg-hover: #f8f9fa;
+  --color-bg-quantity-btn: #f5f5f5;
+  --color-bg-quantity-btn-hover: #e0e0e0;
+  --color-bg-close-btn: #f5f5f5;
+  --color-bg-close-btn-hover: #e0e0e0;
+  --color-bg-table-header: #f8f9fa;
+  --color-bg-action-menu: #ffffff;
+  --color-bg-action-menu-btn: #ffffff;
+  --color-bg-action-menu-btn-hover: #f8f9fa;
+  --color-bg-payment-summary: #f8f9fa;
+  --color-bg-sidebar: #2c3e50;
+
+  --color-text-primary: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #999999;
+  --color-text-on-dark: #ffffff;
+
+  --color-border: #dddddd;
+  --color-border-table: #eeeeee;
+  --color-border-section: #eeeeee;
+
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-shadow-hover: rgba(0, 0, 0, 0.15);
+  --color-modal-overlay: rgba(0, 0, 0, 0.5);
+
+  --color-accent: #007bff;
+  --color-accent-hover: #0056b3;
+  --color-accent-disabled: #cccccc;
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-success: #28a745;
+
+  --color-badge-processing-bg: #fff3cd;
+  --color-badge-processing-text: #856404;
+  --color-badge-shipped-bg: #cce5ff;
+  --color-badge-shipped-text: #004085;
+  --color-badge-completed-bg: #d4edda;
+  --color-badge-completed-text: #155724;
+  --color-badge-canceled-bg: #f8d7da;
+  --color-badge-canceled-text: #721c24;
+  --color-badge-available-bg: #d4edda;
+  --color-badge-available-text: #155724;
+  --color-badge-off-shelf-bg: #f8d7da;
+  --color-badge-off-shelf-text: #721c24;
+}
+
+[data-theme="dark"] {
+  --color-bg-page: #121212;
+  --color-bg-surface: #1e1e1e;
+  --color-bg-muted: #2a2a2a;
+  --color-bg-input: #2a2a2a;
+  --color-bg-hover: #2a2a2a;
+  --color-bg-quantity-btn: #2a2a2a;
+  --color-bg-quantity-btn-hover: #383838;
+  --color-bg-close-btn: #2a2a2a;
+  --color-bg-close-btn-hover: #383838;
+  --color-bg-table-header: #252525;
+  --color-bg-action-menu: #2a2a2a;
+  --color-bg-action-menu-btn: #2a2a2a;
+  --color-bg-action-menu-btn-hover: #333333;
+  --color-bg-payment-summary: #252525;
+  --color-bg-sidebar: #1a2332;
+
+  --color-text-primary: #e0e0e0;
+  --color-text-secondary: #aaaaaa;
+  --color-text-muted: #777777;
+  --color-text-on-dark: #ffffff;
+
+  --color-border: #444444;
+  --color-border-table: #333333;
+  --color-border-section: #333333;
+
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-shadow-hover: rgba(0, 0, 0, 0.6);
+  --color-modal-overlay: rgba(0, 0, 0, 0.75);
+
+  --color-accent: #4da3ff;
+  --color-accent-hover: #2490ff;
+  --color-accent-disabled: #555555;
+  --color-danger: #ff6b7a;
+  --color-danger-hover: #ff4d5f;
+  --color-secondary: #8899aa;
+  --color-secondary-hover: #6b7c8d;
+  --color-success: #5cb85c;
+
+  --color-badge-processing-bg: #3d3010;
+  --color-badge-processing-text: #ffd166;
+  --color-badge-shipped-bg: #0d2a44;
+  --color-badge-shipped-text: #74b9ff;
+  --color-badge-completed-bg: #0d2e17;
+  --color-badge-completed-text: #6fcf97;
+  --color-badge-canceled-bg: #2e0d11;
+  --color-badge-canceled-text: #ff6b7a;
+  --color-badge-available-bg: #0d2e17;
+  --color-badge-available-text: #6fcf97;
+  --color-badge-off-shelf-bg: #2e0d11;
+  --color-badge-off-shelf-text: #ff6b7a;
+}
+
+/* ====== Base Reset & Global Styles ====== */
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +119,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg-page);
+  color: var(--color-text-primary);
+  transition: background-color 0.2s, color 0.2s;
 }
 
 button {
@@ -25,12 +136,14 @@ input, textarea {
   outline: none;
 }
 
+/* ====== Layout ====== */
 .container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
 }
 
+/* ====== Buttons ====== */
 .btn {
   padding: 12px 24px;
   border-radius: 4px;
@@ -40,57 +153,59 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-accent);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-accent-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-accent-disabled);
   cursor: not-allowed;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
+/* ====== Cards ====== */
 .card {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px var(--color-shadow);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background-color 0.2s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 8px var(--color-shadow-hover);
 }
 
+/* ====== Modals ====== */
 .modal-overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-modal-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +213,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-bg-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -106,6 +221,7 @@ input, textarea {
   padding: 24px;
 }
 
+/* ====== Forms ====== */
 .form-group {
   margin-bottom: 16px;
 }
@@ -114,23 +230,50 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--color-bg-input);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s, background-color 0.2s;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-accent);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
+}
+
+/* ====== Dark Mode Toggle Button ====== */
+.theme-toggle {
+  background: transparent;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-radius: 20px;
+  padding: 6px 14px;
+  color: inherit;
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.theme-toggle:hover {
+  border-color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.theme-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
 }


### PR DESCRIPTION
## Summary

Implements dark mode for the demo-shop UI as requested in [crafting-demo/demo-shop#60](https://github.com/crafting-demo/demo-shop/issues/60).

Fixes #60

## Changes

### New: `ThemeContext.tsx`
- React context provider (`ThemeProvider`) managing `light` / `dark` theme state
- Persists selection to `localStorage` across sessions
- Detects system preference (`prefers-color-scheme`) as the default on first visit
- Applies theme via `data-theme` attribute on `<html>` for CSS cascade

### CSS Architecture
- Refactored `shared/styles.css` to define all colors as CSS custom properties (design tokens) under `:root / [data-theme="light"]` and `[data-theme="dark"]`
- All component CSS files (`LandingPage`, `CheckoutPage`, `PaymentPage`, `ProductPage`, `ThankYouPage`, `AdminApp`, `InventoryAdmin`, `OrderAdmin`, `ProductEdit`) updated to consume CSS variables instead of hard-coded values
- Smooth `transition` on `background-color` and `color` for theme switching

### Toggle Button
- 🌙 / ☀️ toggle button visible in:
  - Customer storefront header (LandingPage, CheckoutPage, PaymentPage)
  - Admin sidebar

### Entry Points
- Both `customer/index.tsx` and `admin/index.tsx` wrapped with `<ThemeProvider>`

## Testing

- ✅ TypeScript + Vite build passes with no errors (`npm run build`)
- ✅ Both light and dark palettes verified via CSS variable design tokens
- ✅ Theme persists on page refresh via `localStorage`
- ✅ System preference detected on first visit

## Sandbox / Template

- **Sandbox**: `ai-b3f8c2e1d4a97051`
- **Template**: `demo-shop`