### PR TITLE
feat: implement dark mode for Web UI

### DIFF
--- a/src/ts/web/src/admin/AdminApp.css
+++ b/src/ts/web/src/admin/AdminApp.css
@@ -5,15 +5,15 @@
 
 .sidebar {
   width: 250px;
-  background: #2c3e50;
-  color: white;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
   padding: 24px;
+  transition: background 0.3s;
 }
 
 .sidebar h1 {
   font-size: 24px;
-  margin-bottom: 32px;
-  color: white;
+  color: var(--sidebar-text);
 }
 
 .sidebar nav {
@@ -25,7 +25,7 @@
 .nav-item {
   padding: 12px 16px;
   background: transparent;
-  color: white;
+  color: var(--sidebar-text);
   text-align: left;
   border-radius: 4px;
   font-size: 16px;
@@ -33,11 +33,11 @@
 }
 
 .nav-item:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--sidebar-hover);
 }
 
 .nav-item.active {
-  background: #3498db;
+  background: var(--sidebar-active);
 }
 
 .main-content {

--- a/src/ts/web/src/admin/AdminApp.tsx
+++ b/src/ts/web/src/admin/AdminApp.tsx
@@ -4,6 +4,7 @@ import InventoryAdmin from './pages/InventoryAdmin';
 import ProductEdit from './pages/ProductEdit';
 import OrderAdmin from './pages/OrderAdmin';
 import './AdminApp.css';
+import ThemeToggle from '../shared/ThemeToggle';
 
 type Tab = 'inventory' | 'orders';
 type View = 'list' | 'edit';
@@ -36,7 +37,10 @@ const AdminApp: React.FC = () => {
   return (
     <div className="admin-app">
       <div className="sidebar">
-        <h1>Admin Panel</h1>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '32px' }}>
+          <h1 style={{ marginBottom: 0 }}>Admin Panel</h1>
+          <ThemeToggle />
+        </div>
         <nav>
           <button
             className={`nav-item ${currentTab === 'inventory' ? 'active' : ''}`}

--- a/src/ts/web/src/admin/index.tsx
+++ b/src/ts/web/src/admin/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import AdminApp from './AdminApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -11,8 +12,10 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <ApolloProvider client={apolloClient}>
-      <AdminApp />
-    </ApolloProvider>
+    <ThemeProvider>
+      <ApolloProvider client={apolloClient}>
+        <AdminApp />
+      </ApolloProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/admin/pages/InventoryAdmin.css
+++ b/src/ts/web/src/admin/pages/InventoryAdmin.css
@@ -1,7 +1,8 @@
 .inventory-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background 0.3s;
 }
 
 .page-header {
@@ -13,7 +14,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text);
 }
 
 .page-size-selector {
@@ -24,18 +25,20 @@
 
 .page-size-selector label {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .page-size-selector select {
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .inventory-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -50,18 +53,18 @@
 }
 
 .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
 }
 
 .col-image img {
@@ -73,17 +76,17 @@
 
 .col-id {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-name {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .state-badge {
@@ -94,13 +97,13 @@
 }
 
 .state-badge.available {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-available-bg);
+  color: var(--badge-available-text);
 }
 
 .state-badge.off-shelf {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-off-shelf-bg);
+  color: var(--badge-off-shelf-text);
 }
 
 .col-actions {
@@ -108,26 +111,26 @@
 }
 
 .action-button {
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   border-radius: 4px;
   width: 32px;
   height: 32px;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .action-button:hover {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .action-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   z-index: 10;
   min-width: 150px;
 }
@@ -137,10 +140,10 @@
   width: 100%;
   padding: 12px 16px;
   text-align: left;
-  background: white;
-  color: #333;
+  background: var(--color-surface);
+  color: var(--color-text);
   border: none;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .action-menu button:last-child {
@@ -148,7 +151,7 @@
 }
 
 .action-menu button:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
 }
 
 .pagination {
@@ -161,21 +164,22 @@
 
 .pagination button {
   padding: 8px 16px;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   border-radius: 4px;
 }
 
 .pagination button:disabled {
-  background: #ccc;
+  background: var(--color-secondary);
   cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .pagination button:not(:disabled):hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .pagination span {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }

--- a/src/ts/web/src/admin/pages/OrderAdmin.css
+++ b/src/ts/web/src/admin/pages/OrderAdmin.css
@@ -1,11 +1,12 @@
 .order-admin {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   padding: 24px;
+  transition: background 0.3s;
 }
 
 .order-table {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -20,33 +21,33 @@
 }
 
 .order-table .table-header {
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
   font-weight: 600;
-  color: #333;
-  border-bottom: 2px solid #ddd;
+  color: var(--color-text);
+  border-bottom: 2px solid var(--color-border);
 }
 
 .order-table .table-row {
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .order-table .table-row:hover {
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
 }
 
 .col-id {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
 }
 
 .col-date {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .col-price {
   font-weight: 500;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .col-customer {
@@ -55,25 +56,25 @@
 
 .col-email {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .state-badge.processing {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--badge-processing-bg);
+  color: var(--badge-processing-text);
 }
 
 .state-badge.shipped {
-  background: #cce5ff;
-  color: #004085;
+  background: var(--badge-shipped-bg);
+  color: var(--badge-shipped-text);
 }
 
 .state-badge.completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--badge-completed-bg);
+  color: var(--badge-completed-text);
 }
 
 .state-badge.canceled {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--badge-canceled-bg);
+  color: var(--badge-canceled-text);
 }

--- a/src/ts/web/src/admin/pages/ProductEdit.css
+++ b/src/ts/web/src/admin/pages/ProductEdit.css
@@ -11,7 +11,7 @@
 
 .page-header h1 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text);
 }
 
 .header-actions {
@@ -29,10 +29,10 @@
 
 .form-section h2 {
   font-size: 20px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 24px;
   padding-bottom: 12px;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid var(--color-border-light);
 }
 
 .form-row {
@@ -60,5 +60,5 @@
 
 .form-actions {
   padding-top: 24px;
-  border-top: 2px solid #eee;
+  border-top: 2px solid var(--color-border-light);
 }

--- a/src/ts/web/src/customer/index.tsx
+++ b/src/ts/web/src/customer/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { ApolloProvider } from '@apollo/client';
 import CustomerApp from './CustomerApp';
 import { apolloClient } from '../shared/apolloClient';
+import { ThemeProvider } from '../shared/ThemeContext';
 import '../shared/styles.css';
 
 const root = ReactDOM.createRoot(
@@ -11,8 +12,10 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <ApolloProvider client={apolloClient}>
-      <CustomerApp />
-    </ApolloProvider>
+    <ThemeProvider>
+      <ApolloProvider client={apolloClient}>
+        <CustomerApp />
+      </ApolloProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/ts/web/src/customer/pages/CheckoutPage.css
+++ b/src/ts/web/src/customer/pages/CheckoutPage.css
@@ -9,7 +9,7 @@
 
 .empty-cart p {
   font-size: 24px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 24px;
 }
 
@@ -40,13 +40,13 @@
 
 .item-info h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
 .item-info .price {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .quantity-controls {
@@ -59,13 +59,13 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   font-size: 18px;
-  color: #333;
+  color: var(--color-text);
 }
 
 .quantity-controls button:hover:not(:disabled) {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .quantity-controls button:disabled {
@@ -88,7 +88,7 @@
 .item-total p {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .cart-summary {
@@ -99,7 +99,7 @@
 
 .cart-summary h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 16px;
 }
 
@@ -108,13 +108,13 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-light);
 }
 
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .checkout-btn {

--- a/src/ts/web/src/customer/pages/CheckoutPage.tsx
+++ b/src/ts/web/src/customer/pages/CheckoutPage.tsx
@@ -9,6 +9,7 @@ import {
   RemoveFromCartMutationVariables,
 } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import ThemeToggle from '../../shared/ThemeToggle';
 import './CheckoutPage.css';
 
 interface CheckoutPageProps {
@@ -55,7 +56,7 @@ const CheckoutPage: React.FC<CheckoutPageProps> = ({
           ← Back
         </button>
         <h1>Shopping Cart</h1>
-        <div></div>
+        <ThemeToggle />
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/LandingPage.css
+++ b/src/ts/web/src/customer/pages/LandingPage.css
@@ -3,8 +3,8 @@
 }
 
 .header {
-  background: white;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
   padding: 16px 20px;
   display: flex;
   justify-content: space-between;
@@ -12,16 +12,17 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  transition: background 0.3s;
 }
 
 .header h1 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text);
 }
 
 .cart-button {
   position: relative;
-  background: #007bff;
+  background: var(--color-primary);
   color: white;
   padding: 10px 16px;
   border-radius: 20px;
@@ -32,7 +33,7 @@
 }
 
 .cart-button:hover {
-  background: #0056b3;
+  background: var(--color-primary-hover);
 }
 
 .cart-icon {
@@ -40,7 +41,7 @@
 }
 
 .cart-badge {
-  background: #dc3545;
+  background: var(--color-danger);
   color: white;
   border-radius: 50%;
   width: 20px;
@@ -74,20 +75,20 @@
 
 .product-card h3 {
   font-size: 18px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 8px;
 }
 
 .product-card .price {
   font-size: 20px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
   margin-bottom: 4px;
 }
 
 .product-card .stock {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .observer-target {

--- a/src/ts/web/src/customer/pages/LandingPage.tsx
+++ b/src/ts/web/src/customer/pages/LandingPage.tsx
@@ -4,6 +4,7 @@ import { Product } from '../../shared/types';
 import { GET_PRODUCTS } from '../queries';
 import { GetProductsQuery, GetProductsQueryVariables } from '../../generated/graphql';
 import { getImageUrl } from '../../shared/helpers';
+import ThemeToggle from '../../shared/ThemeToggle';
 import './LandingPage.css';
 
 interface LandingPageProps {
@@ -60,12 +61,15 @@ const LandingPage: React.FC<LandingPageProps> = ({
     <div className="landing-page">
       <header className="header">
         <h1>Shop</h1>
-        <button className="cart-button" onClick={onCartClick}>
-          <span className="cart-icon">🛒</span>
-          {cartItemCount > 0 && (
-            <span className="cart-badge">{cartItemCount}</span>
-          )}
-        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <ThemeToggle />
+          <button className="cart-button" onClick={onCartClick}>
+            <span className="cart-icon">🛒</span>
+            {cartItemCount > 0 && (
+              <span className="cart-badge">{cartItemCount}</span>
+            )}
+          </button>
+        </div>
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/PaymentPage.css
+++ b/src/ts/web/src/customer/pages/PaymentPage.css
@@ -10,19 +10,20 @@
 
 .payment-form h2 {
   font-size: 24px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 24px;
 }
 
 .required {
-  color: #dc3545;
+  color: var(--color-danger);
 }
 
 .payment-summary {
   margin: 32px 0;
   padding: 24px;
-  background: #f8f9fa;
+  background: var(--color-surface-raised);
   border-radius: 8px;
+  transition: background 0.3s;
 }
 
 .payment-summary h2 {
@@ -39,7 +40,7 @@
 .summary-row .total-price {
   font-size: 28px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .place-order-btn {

--- a/src/ts/web/src/customer/pages/PaymentPage.tsx
+++ b/src/ts/web/src/customer/pages/PaymentPage.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@apollo/client';
 import { PLACE_ORDER } from '../queries';
 import { PlaceOrderMutation, PlaceOrderMutationVariables } from '../../generated/graphql';
 import './PaymentPage.css';
+import ThemeToggle from '../../shared/ThemeToggle';
 
 interface PaymentPageProps {
   totalPrice: number; // in cents
@@ -89,7 +90,7 @@ const PaymentPage: React.FC<PaymentPageProps> = ({
           ← Back
         </button>
         <h1>Payment</h1>
-        <div></div>
+        <ThemeToggle />
       </header>
 
       <div className="container">

--- a/src/ts/web/src/customer/pages/ProductPage.css
+++ b/src/ts/web/src/customer/pages/ProductPage.css
@@ -8,7 +8,7 @@
   position: absolute;
   top: 16px;
   right: 16px;
-  background: #f5f5f5;
+  background: var(--color-surface-alt);
   border-radius: 50%;
   width: 32px;
   height: 32px;
@@ -16,12 +16,12 @@
   align-items: center;
   justify-content: center;
   font-size: 20px;
-  color: #666;
+  color: var(--color-text-secondary);
   z-index: 1;
 }
 
 .close-button:hover {
-  background: #e0e0e0;
+  background: var(--color-surface-hover);
 }
 
 .product-detail {
@@ -51,12 +51,12 @@
 
 .product-info h2 {
   font-size: 28px;
-  color: #333;
+  color: var(--color-text);
 }
 
 .product-info .description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
 }
 
@@ -69,12 +69,12 @@
 .product-meta .price {
   font-size: 32px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--color-primary);
 }
 
 .product-meta .stock {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .add-to-cart-btn {

--- a/src/ts/web/src/customer/pages/ThankYouPage.css
+++ b/src/ts/web/src/customer/pages/ThankYouPage.css
@@ -15,7 +15,7 @@
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: #28a745;
+  background: var(--color-success);
   color: white;
   font-size: 48px;
   display: flex;
@@ -26,13 +26,13 @@
 
 .thankyou-card h1 {
   font-size: 32px;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 16px;
 }
 
 .thankyou-card p {
   font-size: 18px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 

--- a/src/ts/web/src/shared/ThemeContext.tsx
+++ b/src/ts/web/src/shared/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved === 'light' || saved === 'dark') return saved;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/src/ts/web/src/shared/ThemeToggle.css
+++ b/src/ts/web/src/shared/ThemeToggle.css
@@ -1,0 +1,18 @@
+.theme-toggle {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.theme-toggle:hover {
+  background: var(--color-surface-hover);
+  transform: scale(1.1);
+}

--- a/src/ts/web/src/shared/ThemeToggle.tsx
+++ b/src/ts/web/src/shared/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTheme } from './ThemeContext';
+import './ThemeToggle.css';
+
+const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/ts/web/src/shared/styles.css
+++ b/src/ts/web/src/shared/styles.css
@@ -1,3 +1,101 @@
+:root {
+  /* Background */
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f5f5f5;
+  --color-surface-hover: #e0e0e0;
+  --color-surface-raised: #f8f9fa;
+
+  /* Text */
+  --color-text: #333333;
+  --color-text-secondary: #666666;
+
+  /* Brand */
+  --color-primary: #007bff;
+  --color-primary-hover: #0056b3;
+  --color-danger: #dc3545;
+  --color-danger-hover: #c82333;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #545b62;
+  --color-success: #28a745;
+
+  /* Borders & Shadows */
+  --color-border: #dddddd;
+  --color-border-light: #eeeeee;
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --color-overlay: rgba(0, 0, 0, 0.5);
+
+  /* State badges */
+  --badge-available-bg: #d4edda;
+  --badge-available-text: #155724;
+  --badge-off-shelf-bg: #f8d7da;
+  --badge-off-shelf-text: #721c24;
+  --badge-processing-bg: #fff3cd;
+  --badge-processing-text: #856404;
+  --badge-shipped-bg: #cce5ff;
+  --badge-shipped-text: #004085;
+  --badge-completed-bg: #d4edda;
+  --badge-completed-text: #155724;
+  --badge-canceled-bg: #f8d7da;
+  --badge-canceled-text: #721c24;
+
+  /* Admin sidebar */
+  --sidebar-bg: #2c3e50;
+  --sidebar-text: #ffffff;
+  --sidebar-active: #3498db;
+  --sidebar-hover: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] {
+  /* Background */
+  --color-bg: #121212;
+  --color-surface: #1e1e1e;
+  --color-surface-alt: #2a2a2a;
+  --color-surface-hover: #3a3a3a;
+  --color-surface-raised: #252525;
+
+  /* Text */
+  --color-text: #e0e0e0;
+  --color-text-secondary: #a0a0a0;
+
+  /* Brand */
+  --color-primary: #4da3ff;
+  --color-primary-hover: #80bdff;
+  --color-danger: #ff6b7a;
+  --color-danger-hover: #ff4757;
+  --color-secondary: #8a9aad;
+  --color-secondary-hover: #a0b0c0;
+  --color-success: #4caf50;
+
+  /* Borders & Shadows */
+  --color-border: #3a3a3a;
+  --color-border-light: #2e2e2e;
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
+  --color-overlay: rgba(0, 0, 0, 0.7);
+
+  /* State badges */
+  --badge-available-bg: #1b4332;
+  --badge-available-text: #95d5b2;
+  --badge-off-shelf-bg: #4a1520;
+  --badge-off-shelf-text: #f4a0a8;
+  --badge-processing-bg: #3d3200;
+  --badge-processing-text: #ffe066;
+  --badge-shipped-bg: #0a2744;
+  --badge-shipped-text: #80c0ff;
+  --badge-completed-bg: #1b4332;
+  --badge-completed-text: #95d5b2;
+  --badge-canceled-bg: #4a1520;
+  --badge-canceled-text: #f4a0a8;
+
+  /* Admin sidebar */
+  --sidebar-bg: #1a1a2e;
+  --sidebar-text: #e0e0e0;
+  --sidebar-active: #4da3ff;
+  --sidebar-hover: rgba(255, 255, 255, 0.08);
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -10,7 +108,9 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  transition: background-color 0.3s, color 0.3s;
 }
 
 button {
@@ -40,48 +140,49 @@ input, textarea {
 }
 
 .btn-primary {
-  background-color: #007bff;
+  background-color: var(--color-primary);
   color: white;
 }
 
 .btn-primary:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-hover);
 }
 
 .btn-primary:disabled {
-  background-color: #ccc;
+  background-color: var(--color-secondary);
   cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .btn-secondary {
-  background-color: #6c757d;
+  background-color: var(--color-secondary);
   color: white;
 }
 
 .btn-secondary:hover {
-  background-color: #545b62;
+  background-color: var(--color-secondary-hover);
 }
 
 .btn-danger {
-  background-color: #dc3545;
+  background-color: var(--color-danger);
   color: white;
 }
 
 .btn-danger:hover {
-  background-color: #c82333;
+  background-color: var(--color-danger-hover);
 }
 
 .card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   padding: 16px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.3s;
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
 .modal-overlay {
@@ -90,7 +191,7 @@ input, textarea {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -98,7 +199,7 @@ input, textarea {
 }
 
 .modal-content {
-  background: white;
+  background: var(--color-surface);
   border-radius: 8px;
   max-width: 90%;
   max-height: 90%;
@@ -114,23 +215,26 @@ input, textarea {
   display: block;
   margin-bottom: 4px;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
 }
 
 .form-input {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   font-size: 14px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  transition: border-color 0.2s, background 0.3s;
 }
 
 .form-input:focus {
-  border-color: #007bff;
+  border-color: var(--color-primary);
 }
 
 .error-message {
-  color: #dc3545;
+  color: var(--color-danger);
   font-size: 14px;
   margin-top: 4px;
 }


### PR DESCRIPTION
## Summary

Implements dark mode for the Web UI across both **Customer** and **Admin** interfaces.

Closes [crafting-demo/demo-shop#63](https://github.com/crafting-demo/demo-shop/issues/63)

## Changes

### New Files
- **`src/ts/web/src/shared/ThemeContext.tsx`** — React context for theme state management
  - Persists user preference to `localStorage`
  - Respects OS `prefers-color-scheme` setting on first visit
  - Sets `data-theme` attribute on `<html>` element
- **`src/ts/web/src/shared/ThemeToggle.tsx`** — Toggle button component (🌙/☀️)
- **`src/ts/web/src/shared/ThemeToggle.css`** — Styles for the toggle button

### Modified Files
- **`src/ts/web/src/shared/styles.css`** — Refactored to use CSS custom properties with `:root` (light) and `[data-theme="dark"]` (dark) variable definitions. Covers backgrounds, text colors, brand colors, borders, shadows, state badge colors, and admin sidebar.
- **All CSS files** (12 files) — Replaced hardcoded color values with CSS custom properties (`var(--color-*)`)
- **`src/ts/web/src/customer/index.tsx`** & **`src/ts/web/src/admin/index.tsx`** — Wrapped apps with `ThemeProvider`
- **`src/ts/web/src/customer/pages/LandingPage.tsx`** — Added `ThemeToggle` to header
- **`src/ts/web/src/customer/pages/CheckoutPage.tsx`** — Added `ThemeToggle` to header
- **`src/ts/web/src/customer/pages/PaymentPage.tsx`** — Added `ThemeToggle` to header
- **`src/ts/web/src/admin/AdminApp.tsx`** — Added `ThemeToggle` to sidebar

## Design Approach
- Uses CSS custom properties for zero-overhead theme switching
- Smooth 0.3s transitions between themes
- Dark theme uses proper dark palette with good contrast ratios
- All state badges (Available, Off-shelf, Processing, Shipped, etc.) have dark-mode-appropriate colors
- Theme toggle is accessible with `aria-label` and `title` attributes

## Testing
- ✅ TypeScript type-check passes (`tsc --noEmit`)
- ✅ Full build passes (`./scripts/build-all.sh`)
- ✅ CSS variables correctly present in production build output
- ✅ No existing API tests affected (dark mode is purely frontend)

## Sandbox & Template
- **Sandbox:** `ai-d7f3a1b9c4e20816`
- **Template:** `demo-shop`